### PR TITLE
Adds crouch sliding, QOL stuff, more menu customization functionality 

### DIFF
--- a/BCoreProV55/Classes/AimComponent.uc
+++ b/BCoreProV55/Classes/AimComponent.uc
@@ -295,7 +295,7 @@ final simulated function OnWeaponSelected()
 {
 	OldLookDir = BW.GetPlayerAim();
 
-	bSprintOffset = (BW.SprintControl != None && BW.SprintControl.bSprintActive);
+	bSprintOffset = (BW.SprintControl != None && BW.SprintControl.bSprintActive && class'BallisticReplicationInfo'.default.bWeaponJumpOffsetting);
 
 	AimOffset = CalcNewAimOffset();
 	NewAimOffset = AimOffset;

--- a/BCoreProV55/Classes/BCSprintControl.uc
+++ b/BCoreProV55/Classes/BCSprintControl.uc
@@ -23,9 +23,6 @@ var   	float    	MaxStamina;				// should always be 100
 var() 	float		StaminaDrainRate;		// Amount of stamina lost each second when sprinting
 var() 	float		StaminaChargeRate;		// Amount of stamina gained each second when not sprinting
 var() 	float		StaminaRechargeDelay;	// From RECHARGE_DELAY
-var 	name 		SlideAnims[4]; 
-var 	name 		SlideStartAnims[4]; 
-var 	name 		SlideEndAnims[4]; 
 
 //=============================================================================
 // SPRINT VARIABLES
@@ -50,33 +47,14 @@ var array<SlowInfo> ActiveSlows;			// Effects which slow movement
 var float SlowFactor; 
 var float NextTimerPop;				// Next time to check for slow expiry
 
-// Sliding Variables
-var bool bIsSliding;			 // Is the player currently sliding?
-var float LastSlideEndTime;		// Time when the last slide ended
-var float LastLandTime;			// Time when the player last landed
-var vector SlideVelocity;		// Velocity during the slide
-var float SlideStartSpeed;		 // Speed required to start sliding
-var float SlideStopSpeed;		 // Speed below which sliding stops
-var float MaxSlideSpeed;		// Maximum speed during sliding, our groundspeed becomes this in order to move faster
-var float BaseGroundSpeed;		 // Base ground speed of the player when not sliding
-var float SlideEyeHeight;		 // Eye height during sliding, used to adjust camera position
-
 // --- Slide/Movement Parameters ---
-var() float SlideFriction;		 // Friction applied during sliding, affects how quickly the player slows down
-var() float SlideCooldownTime;	// Time before the player can slide again after a slide ends
-var() float SlidePower;			 // Initial burst power when starting a slide, affects how fast the player accelerates at the start of the slide
+var float BaseGroundSpeed;		 // Base ground speed of the player when not sliding
 
-// Slope/Physics Calculations
-var float SlopeAngleRad;		 // Angle of the slope in radians
-var float SlopeAngleDeg;		 // Angle of the slope in degrees
-var vector DownSlopeVect;		 // Direction vector pointing down the slope
-var vector LastFallingVelocity;	 // Velocity of the player when they last fell, used to determine sliding behavior
-var float GravityAlongSlope;	 // Gravity component acting along the slope, used to calculate acceleration during sliding
 
 replication
 {
 	reliable if (Role == ROLE_Authority)
-		bSprintActive, bIsSliding, SlideVelocity,
+		bSprintActive,
 		ClientJumped, ClientDelayRecharge;
 }
 
@@ -151,8 +129,6 @@ simulated event Tick(float DT)
 		Destroy();
 
 	TickSprint(DT);
-
-	TickSlopeCalculation(DT);
 }
 
 //=============================================================================
@@ -207,14 +183,6 @@ function OwnerEvent(name EventName)
 		{
 			Jumped();
 			ClientJumped();
-		}
-		if(EventName == 'Crouched')
-		{
-			TryStartSlide();
-		}
-		if(EventName == 'Landed')
-		{
-			DoLand();
 		}
 	}
 }
@@ -298,38 +266,13 @@ simulated function TickSprint(float DT)
 		{
 			if (VSize(Instigator.Velocity) == 0)
 				Stamina += StaminaChargeRate * DT;
-			else if (Instigator.bIsCrouched && !bIsSliding)
+			else if (Instigator.bIsCrouched)
 				Stamina += StaminaChargeRate * DT/2;
 			if (Level.TimeSeconds > SprintRechargeDelay)
 				Stamina += StaminaChargeRate * DT;
 		}
 	}
 	Stamina = FClamp(Stamina, 0, MaxStamina);
-	if (Instigator.Physics == PHYS_Falling)
-    	LastFallingVelocity = Instigator.Velocity;
-	SlideEyeHeight = Instigator.BaseEyeHeight;
-
-	if (bIsSliding)
-    {
-        HandleSliding(DT);
-		Instigator.EyeHeight = SlideEyeHeight * 0.6; // Lower eye height while sliding
-    }
-    else
-    {
-        if (Instigator.Physics == PHYS_Walking)
-        {
-            SlideStartSpeed = class'BallisticReplicationInfo'.default.PlayerGroundSpeed*1.1;
-            SlideStopSpeed = BaseGroundSpeed*0.2;
-            MaxSlideSpeed = BaseGroundSpeed*2.5;
-			if(Level.TimeSeconds > LastLandTime + 0.1)
-				LastFallingVelocity = vect(0,0,0); 
-        }
-		if (Instigator.bIsCrouched)
-		{
-        	Instigator.CrouchedPct = Instigator.default.CrouchedPct;
-			Instigator.EyeHeight = Lerp(DT * 1.5, Instigator.EyeHeight, SlideEyeHeight, true); 
-		}
-    }
 }
 
 simulated event RenderOverlays( canvas C )
@@ -517,139 +460,6 @@ function AddNewSlow()
 	ActiveSlows[ActiveSlows.Length] = S;
 }
 
-//=============================================================================
-// SLIDING
-//=============================================================================
-
-function StartSlide()
-{
-    local name Anim;
-
-    if (!bIsSliding 
-	&& Instigator.Controller.bDuck > 0 
-	&& (VSize(LastFallingVelocity) > SlideStartSpeed || VSize(Instigator.Velocity) > SlideStartSpeed || SlopeAngleDeg < 0.0)
-	&& Instigator.Physics == PHYS_Walking 
-	&& (Level.TimeSeconds - LastSlideEndTime > SlideCooldownTime))
-    {
-		DelayRecharge();
-		StopSprint();
-		SlideVelocity = Instigator.Velocity * 0.5 + LastFallingVelocity * 0.5; //Blend current velocity with last falling velocity
-		SlideVelocity += Normal(SlideVelocity) * FMax(SlidePower*0.5,SlidePower * (Stamina / MaxStamina));
-		// Clamp slide velocity to max speed
-        if (VSize(SlideVelocity) > MaxSlideSpeed)
-            SlideVelocity = Normal(SlideVelocity) * MaxSlideSpeed;
-		LastFallingVelocity = vect(0,0,0); 
-        bIsSliding = true;
-        Instigator.GroundSpeed = MaxSlideSpeed;
-
-        Anim = SlideStartAnims[Instigator.Get4WayDirection()];
-        if ( Instigator.PlayAnim(Anim, 1.0, 0.1) )
-            Instigator.bWaitForAnim = true;
-        Instigator.AnimAction = Anim;
-    }
-}
-
-function EndSlide()
-{
-	local name Anim;
-
-	if(!Instigator.bIsCrouched && VSize(Instigator.Velocity) < SlideStopSpeed + 50.0) //Play this if not crouched and below certain speed so it looks natural
-	{
-		Anim = SlideEndAnims[Instigator.Get4WayDirection()];
-		if ( Instigator.PlayAnim(Anim, 1.0, 0.1) )
-			Instigator.bWaitForAnim = true;
-		Instigator.AnimAction = Anim;
-	}
-
-    bIsSliding = false;
-    SlideVelocity = vect(0,0,0);
-    LastSlideEndTime = Level.TimeSeconds;
-    Instigator.GroundSpeed = BaseGroundSpeed;
-}
-
-simulated function TickSlopeCalculation(float DT)
-{
-	DownSlopeVect = Normal(vect(0,0,-1) - (Instigator.Floor dot vect(0,0,-1)) * Instigator.Floor);
-	SlopeAngleRad = Acos(Instigator.Floor dot vect(0,0,1));
-	SlopeAngleDeg = SlopeAngleRad * (180.0 / Pi);
-	if (Normal(Instigator.Velocity) dot DownSlopeVect > 0)
-		SlopeAngleDeg = -SlopeAngleDeg; // Negative when going downhill
-}
-
-simulated function HandleSliding(float DT)
-{
-	local float DynamicFriction;
-	local name Anim;
-
-	Instigator.CrouchedPct = 1.0; //Little hack so it doesn't mess with crouch speed/ground speed, etc...
-	GravityAlongSlope = -PhysicsVolume.Gravity.Z * Sin(SlopeAngleRad);
-	// Friction increases over time
-	DynamicFriction = SlideFriction;
-	// Reduce friction on steep slopes for more sliding
-	if (SlopeAngleDeg < 0) // Downhill
-		DynamicFriction *= FClamp(1.0 - (Abs(SlopeAngleDeg) / 60.0), 0.2, 1.0);
-	else  // Uphill
-		DynamicFriction *= FClamp(1.0 + (SlopeAngleDeg / 45.0), 1.0, 2.5);
-	//Need to make sure we only apply this when on stairs, DetectStairDirection() might return an angle when on a slope that is not a stair
-	
-	//If we're on stairs, but not on a slope, adjust friction and gravity, hacky but it works!
-	if(SlopeAngleDeg == 0.0 && Instigator.Floor != Vect(0,0,1)) 
-	{
-		if (PlayerController(Instigator.Controller).FindStairRotation(DT) < 0) 
-		{
-			DynamicFriction *= 0.5;
-			GravityAlongSlope *= 1.5; 
-		}
-		else
-		{
-			DynamicFriction *= 1.5;
-			GravityAlongSlope *= 0.5; 
-		}
-	}
-	
-	// If going downhill, accelerate; if uphill, decelerate
-	SlideVelocity += DownSlopeVect * GravityAlongSlope * 1.5 * DT;
-
-	// Friction force
-	if (VSize(SlideVelocity) > 0.1)
-		SlideVelocity -= Normal(SlideVelocity) * DynamicFriction * -PhysicsVolume.Gravity.Z * Cos(SlopeAngleRad) * DT;
-
-	// Apply slide velocity to pawn
-	if (Instigator.Physics == PHYS_Walking)
-	{
-		Instigator.Velocity = Instigator.Velocity * 0.3 + SlideVelocity * 0.7;
-		if (VSize(Instigator.Velocity) > MaxSlideSpeed)
-			Instigator.Velocity = Normal(Instigator.Velocity) * MaxSlideSpeed;
-	}
-
-	Anim = SlideAnims[Instigator.Get4WayDirection()];
-	Instigator.LoopAnim(Anim, 1.0, 0.2);
-
-	// End slide if crouch released, speed too low, or airborne
-	if (!Instigator.bIsCrouched || VSize(SlideVelocity) < SlideStopSpeed || Instigator.Physics != PHYS_Walking)
-	{
-		EndSlide();
-	}
-}
-
-simulated function TryStartSlide()
-{
-    if (Role < ROLE_Authority)
-        ServerStartSlide();
-    else
-        StartSlide();
-}
-
-function ServerStartSlide()
-{
-    StartSlide();
-}
-
-simulated function DoLand()
-{
-	LastLandTime = Level.TimeSeconds;
-}
-
 defaultproperties
 {
      Stamina=100.000000
@@ -660,19 +470,4 @@ defaultproperties
      SpeedFactor=1.500000
 	 SlowFactor=1.000000
      bReplicateInstigator=True
-	 SlideFriction=1.100000
-     SlideCooldownTime=0.600000
-	 SlidePower=300.000000
-	 SlideAnims(0)="SlideF"
-	 SlideAnims(1)="SlideF"
-	 SlideAnims(2)="SlideL"
-	 SlideAnims(3)="SlideR"
-	 SlideStartAnims(0)="SlideFStart"
-	 SlideStartAnims(1)="SlideFStart"
-	 SlideStartAnims(2)="SlideLStart"
-	 SlideStartAnims(3)="SlideRStart"
-	 SlideEndAnims(0)="SlideFEnd"
-	 SlideEndAnims(1)="SlideFEnd"
-	 SlideEndAnims(2)="SlideLEnd"
-	 SlideEndAnims(3)="SlideRSEnd"
 }

--- a/BCoreProV55/Classes/BCSprintControl.uc
+++ b/BCoreProV55/Classes/BCSprintControl.uc
@@ -9,9 +9,11 @@
 // by Nolan "Dark Carnivour" Richert and Azarael
 // Copyright(c) 2005 RuneStorm. All Rights Reserved.
 //=============================================================================
+// Updates by YoYoBatty:
+// - Added crouch sliding functionality
 class BCSprintControl extends Inventory;
 
-const RECHARGE_DELAY = 1.5f;
+//const RECHARGE_DELAY = 1.5f; //This really should be customizable, but for now it's hardcoded
 
 //=============================================================================
 // STAMINA VARIABLES
@@ -20,6 +22,7 @@ var 	float		Stamina;				// Stamina level of player (percentage). Players can't s
 var   	float    	MaxStamina;				// should always be 100
 var() 	float		StaminaDrainRate;		// Amount of stamina lost each second when sprinting
 var() 	float		StaminaChargeRate;		// Amount of stamina gained each second when not sprinting
+var() 	float		StaminaRechargeDelay;	// From RECHARGE_DELAY
 
 //=============================================================================
 // SPRINT VARIABLES
@@ -44,16 +47,41 @@ var array<SlowInfo> ActiveSlows;			// Effects which slow movement
 var float SlowFactor; 
 var float NextTimerPop;				// Next time to check for slow expiry
 
+// Sliding Variables
+var bool bIsSliding;			 // Is the player currently sliding?
+var float LastSlideEndTime;		// Time when the last slide ended
+var float LastLandTime;			// Time when the player last landed
+var vector SlideVelocity;		// Velocity during the slide
+var float SlideStartSpeed;		 // Speed required to start sliding
+var float SlideStopSpeed;		 // Speed below which sliding stops
+var float MaxSlideSpeed;		// Maximum speed during sliding, our groundspeed becomes this in order to move faster
+var float BaseGroundSpeed;		 // Base ground speed of the player when not sliding
+var float SlideEyeHeight;		 // Eye height during sliding, used to adjust camera position
+
+// --- Slide/Movement Parameters ---
+var() float SlideFriction;		 // Friction applied during sliding, affects how quickly the player slows down
+var() float SlideCooldownTime;	// Time before the player can slide again after a slide ends
+var() float SlidePower;			 // Initial burst power when starting a slide, affects how fast the player accelerates at the start of the slide
+
+// Slope/Physics Calculations
+var float SlopeAngleRad;		 // Angle of the slope in radians
+var float SlopeAngleDeg;		 // Angle of the slope in degrees
+var vector DownSlopeVect;		 // Direction vector pointing down the slope
+var vector LastFallingVelocity;	 // Velocity of the player when they last fell, used to determine sliding behavior
+var float GravityAlongSlope;	 // Gravity component acting along the slope, used to calculate acceleration during sliding
+
 replication
 {
 	reliable if (Role == ROLE_Authority)
-		bSprintActive, ClientJumped, ClientDelayRecharge;
+		bSprintActive, bIsSliding, SlideVelocity,
+		ClientJumped, ClientDelayRecharge;
 }
 
 simulated function PostBeginPlay()
 {
 	StaminaChargeRate = class'BallisticReplicationInfo'.default.StaminaChargeRate;
 	StaminaDrainRate = class'BallisticReplicationInfo'.default.StaminaDrainRate;
+	StaminaRechargeDelay = class'BallisticReplicationInfo'.default.StaminaRechargeDelay;
 	SpeedFactor = class'BallisticReplicationInfo'.default.SprintSpeedFactor;
 	JumpDrain = class'BallisticReplicationInfo'.default.JumpDrain;
 }
@@ -110,7 +138,8 @@ function UpdateSpeed()
 	if (Instigator.GroundSpeed != NewSpeed)
 		Instigator.GroundSpeed = NewSpeed;
 
-    //log("SC UpdateSpeed: "$NewSpeed);
+	BaseGroundSpeed = NewSpeed;
+
 }
 
 simulated event Tick(float DT)
@@ -119,6 +148,8 @@ simulated event Tick(float DT)
 		Destroy();
 
 	TickSprint(DT);
+
+	TickSlopeCalculation(DT);
 }
 
 //=============================================================================
@@ -139,6 +170,8 @@ function StartSprint()
 
 	if (Instigator != None)
         UpdateSpeed();
+
+	//Level.Game.Broadcast(self, "Started sprint, ground speed: " $ Instigator.GroundSpeed);
 }
 
 // Sprint Key released. Used on Client and Server
@@ -157,6 +190,8 @@ function StopSprint()
 
     DelayRecharge();
     ClientDelayRecharge();
+
+	//Level.Game.Broadcast(self, "Stopped sprint, ground speed: " $ Instigator.GroundSpeed);
 }
 
 function OwnerEvent(name EventName)
@@ -170,12 +205,20 @@ function OwnerEvent(name EventName)
 			Jumped();
 			ClientJumped();
 		}
+		if(EventName == 'Crouched')
+		{
+			TryStartSlide();
+		}
+		if(EventName == 'Landed')
+		{
+			DoLand();
+		}
 	}
 }
 
 simulated function DelayRecharge()
 {
-	SprintRechargeDelay = Level.TimeSeconds + RECHARGE_DELAY;
+	SprintRechargeDelay = Level.TimeSeconds + StaminaRechargeDelay;
 }
 
 simulated function Jumped()
@@ -252,13 +295,38 @@ simulated function TickSprint(float DT)
 		{
 			if (VSize(Instigator.Velocity) == 0)
 				Stamina += StaminaChargeRate * DT;
-			else if (Instigator.bIsCrouched)
+			else if (Instigator.bIsCrouched && !bIsSliding)
 				Stamina += StaminaChargeRate * DT/2;
 			if (Level.TimeSeconds > SprintRechargeDelay)
 				Stamina += StaminaChargeRate * DT;
 		}
 	}
 	Stamina = FClamp(Stamina, 0, MaxStamina);
+	if (Instigator.Physics == PHYS_Falling)
+    	LastFallingVelocity = Instigator.Velocity;
+	SlideEyeHeight = Instigator.BaseEyeHeight;
+
+	if (bIsSliding)
+    {
+        HandleSliding(DT);
+		Instigator.EyeHeight = SlideEyeHeight * 0.6; // Lower eye height while sliding
+    }
+    else
+    {
+        if (Instigator.Physics == PHYS_Walking)
+        {
+            SlideStartSpeed = class'BallisticReplicationInfo'.default.PlayerGroundSpeed*1.1;
+            SlideStopSpeed = BaseGroundSpeed*0.2;
+            MaxSlideSpeed = BaseGroundSpeed*2.5;
+			if(Level.TimeSeconds > LastLandTime + 0.1)
+				LastFallingVelocity = vect(0,0,0); 
+        }
+		if (Instigator.bIsCrouched)
+		{
+        	Instigator.CrouchedPct = Instigator.default.CrouchedPct;
+			Instigator.EyeHeight = Lerp(DT * 1.5, Instigator.EyeHeight, SlideEyeHeight, true); 
+		}
+    }
 }
 
 simulated event RenderOverlays( canvas C )
@@ -446,14 +514,130 @@ function AddNewSlow()
 	ActiveSlows[ActiveSlows.Length] = S;
 }
 
+//=============================================================================
+// SLIDING
+//=============================================================================
+
+function StartSlide()
+{
+    if (!bIsSliding 
+	&& Instigator.Controller.bDuck > 0 
+	&& (VSize(LastFallingVelocity) > SlideStartSpeed || VSize(Instigator.Velocity) > SlideStartSpeed || SlopeAngleDeg < 0.0)
+	&& Instigator.Physics == PHYS_Walking 
+	&& (Level.TimeSeconds - LastSlideEndTime > SlideCooldownTime))
+    {
+		DelayRecharge();
+		StopSprint();
+		//SlideCooldownTime = default.SlideCooldownTime * FClamp(Instigator.GroundSpeed / 440.0, 0.5, 2.0); //Do we need this?
+		SlideVelocity = Instigator.Velocity * 0.5 + LastFallingVelocity * 0.5; //Blend current velocity with last falling velocity
+		SlideVelocity += Normal(SlideVelocity) * FMax(SlidePower*0.5,SlidePower * (Stamina / MaxStamina));
+		// Clamp slide velocity to max speed
+        if (VSize(SlideVelocity) > MaxSlideSpeed)
+            SlideVelocity = Normal(SlideVelocity) * MaxSlideSpeed;
+		LastFallingVelocity = vect(0,0,0); 
+        bIsSliding = true;
+        Instigator.GroundSpeed = MaxSlideSpeed;
+    }
+}
+
+function EndSlide()
+{
+    bIsSliding = false;
+    SlideVelocity = vect(0,0,0);
+    LastSlideEndTime = Level.TimeSeconds;
+    Instigator.GroundSpeed = BaseGroundSpeed;
+}
+
+simulated function TickSlopeCalculation(float DT)
+{
+	DownSlopeVect = Normal(vect(0,0,-1) - (Instigator.Floor dot vect(0,0,-1)) * Instigator.Floor);
+	SlopeAngleRad = Acos(Instigator.Floor dot vect(0,0,1));
+	SlopeAngleDeg = SlopeAngleRad * (180.0 / Pi);
+	if (Normal(Instigator.Velocity) dot DownSlopeVect > 0)
+		SlopeAngleDeg = -SlopeAngleDeg; // Negative when going downhill
+}
+
+simulated function HandleSliding(float DT)
+{
+	local float DynamicFriction;
+
+	Instigator.CrouchedPct = 1.0; //Little hack so it doesn't mess with crouch speed/ground speed, etc...
+	GravityAlongSlope = -PhysicsVolume.Gravity.Z * Sin(SlopeAngleRad);
+	// Friction increases over time
+	DynamicFriction = SlideFriction;
+	// Reduce friction on steep slopes for more sliding
+	if (SlopeAngleDeg < 0) // Downhill
+		DynamicFriction *= FClamp(1.0 - (Abs(SlopeAngleDeg) / 60.0), 0.2, 1.0);
+	else  // Uphill
+		DynamicFriction *= FClamp(1.0 + (SlopeAngleDeg / 45.0), 1.0, 2.5);
+	//Need to make sure we only apply this when on stairs, DetectStairDirection() might return an angle when on a slope that is not a stair
+	
+	//If we're on stairs, but not on a slope, adjust friction and gravity, hacky but it works!
+	if(SlopeAngleDeg == 0.0 && Instigator.Floor != Vect(0,0,1)) 
+	{
+		if (PlayerController(Instigator.Controller).FindStairRotation(DT) < 0) 
+		{
+			DynamicFriction *= 0.5;
+			GravityAlongSlope *= 1.5; 
+		}
+		else
+		{
+			DynamicFriction *= 1.5;
+			GravityAlongSlope *= 0.5; 
+		}
+	}
+	
+	// If going downhill, accelerate; if uphill, decelerate
+	SlideVelocity += DownSlopeVect * GravityAlongSlope * 1.5 * DT;
+
+	// Friction force
+	if (VSize(SlideVelocity) > 0.1)
+		SlideVelocity -= Normal(SlideVelocity) * DynamicFriction * -PhysicsVolume.Gravity.Z * Cos(SlopeAngleRad) * DT;
+
+	// End slide if crouch released, speed too low, or airborne
+	if (!Instigator.bIsCrouched || VSize(SlideVelocity) < SlideStopSpeed || Instigator.Physics != PHYS_Walking)
+	{
+		EndSlide();
+	}
+
+	// Apply slide velocity to pawn
+	if (Instigator.Physics == PHYS_Walking)
+	{
+		Instigator.Velocity = Instigator.Velocity * 0.3 + SlideVelocity * 0.7;
+		if (VSize(Instigator.Velocity) > MaxSlideSpeed)
+			Instigator.Velocity = Normal(Instigator.Velocity) * MaxSlideSpeed;
+	}
+}
+
+simulated function TryStartSlide()
+{
+    if (Role < ROLE_Authority)
+        ServerStartSlide();
+    else
+        StartSlide();
+}
+
+function ServerStartSlide()
+{
+    StartSlide();
+}
+
+simulated function DoLand()
+{
+	LastLandTime = Level.TimeSeconds;
+}
+
 defaultproperties
 {
      Stamina=100.000000
      MaxStamina=100.000000
      StaminaDrainRate=25.000000
      StaminaChargeRate=25.000000
-	 JumpDrain=10
+	 JumpDrain=10.000000
      SpeedFactor=1.500000
 	 SlowFactor=1.000000
      bReplicateInstigator=True
+	 SlideFriction=1.100000
+     SlideCooldownTime=0.600000
+	 SlidePower=300.000000
 }

--- a/BCoreProV55/Classes/BCSprintControl.uc
+++ b/BCoreProV55/Classes/BCSprintControl.uc
@@ -23,6 +23,9 @@ var   	float    	MaxStamina;				// should always be 100
 var() 	float		StaminaDrainRate;		// Amount of stamina lost each second when sprinting
 var() 	float		StaminaChargeRate;		// Amount of stamina gained each second when not sprinting
 var() 	float		StaminaRechargeDelay;	// From RECHARGE_DELAY
+var 	name 		SlideAnims[4]; 
+var 	name 		SlideStartAnims[4]; 
+var 	name 		SlideEndAnims[4]; 
 
 //=============================================================================
 // SPRINT VARIABLES
@@ -520,6 +523,8 @@ function AddNewSlow()
 
 function StartSlide()
 {
+    local name Anim;
+
     if (!bIsSliding 
 	&& Instigator.Controller.bDuck > 0 
 	&& (VSize(LastFallingVelocity) > SlideStartSpeed || VSize(Instigator.Velocity) > SlideStartSpeed || SlopeAngleDeg < 0.0)
@@ -536,11 +541,26 @@ function StartSlide()
 		LastFallingVelocity = vect(0,0,0); 
         bIsSliding = true;
         Instigator.GroundSpeed = MaxSlideSpeed;
+
+        Anim = SlideStartAnims[Instigator.Get4WayDirection()];
+        if ( Instigator.PlayAnim(Anim, 1.0, 0.1) )
+            Instigator.bWaitForAnim = true;
+        Instigator.AnimAction = Anim;
     }
 }
 
 function EndSlide()
 {
+	local name Anim;
+
+	if(!Instigator.bIsCrouched && VSize(Instigator.Velocity) < SlideStopSpeed + 50.0) //Play this if not crouched and below certain speed so it looks natural
+	{
+		Anim = SlideEndAnims[Instigator.Get4WayDirection()];
+		if ( Instigator.PlayAnim(Anim, 1.0, 0.1) )
+			Instigator.bWaitForAnim = true;
+		Instigator.AnimAction = Anim;
+	}
+
     bIsSliding = false;
     SlideVelocity = vect(0,0,0);
     LastSlideEndTime = Level.TimeSeconds;
@@ -559,6 +579,7 @@ simulated function TickSlopeCalculation(float DT)
 simulated function HandleSliding(float DT)
 {
 	local float DynamicFriction;
+	local name Anim;
 
 	Instigator.CrouchedPct = 1.0; //Little hack so it doesn't mess with crouch speed/ground speed, etc...
 	GravityAlongSlope = -PhysicsVolume.Gravity.Z * Sin(SlopeAngleRad);
@@ -593,18 +614,21 @@ simulated function HandleSliding(float DT)
 	if (VSize(SlideVelocity) > 0.1)
 		SlideVelocity -= Normal(SlideVelocity) * DynamicFriction * -PhysicsVolume.Gravity.Z * Cos(SlopeAngleRad) * DT;
 
-	// End slide if crouch released, speed too low, or airborne
-	if (!Instigator.bIsCrouched || VSize(SlideVelocity) < SlideStopSpeed || Instigator.Physics != PHYS_Walking)
-	{
-		EndSlide();
-	}
-
 	// Apply slide velocity to pawn
 	if (Instigator.Physics == PHYS_Walking)
 	{
 		Instigator.Velocity = Instigator.Velocity * 0.3 + SlideVelocity * 0.7;
 		if (VSize(Instigator.Velocity) > MaxSlideSpeed)
 			Instigator.Velocity = Normal(Instigator.Velocity) * MaxSlideSpeed;
+	}
+
+	Anim = SlideAnims[Instigator.Get4WayDirection()];
+	Instigator.LoopAnim(Anim, 1.0, 0.2);
+
+	// End slide if crouch released, speed too low, or airborne
+	if (!Instigator.bIsCrouched || VSize(SlideVelocity) < SlideStopSpeed || Instigator.Physics != PHYS_Walking)
+	{
+		EndSlide();
 	}
 }
 
@@ -639,4 +663,16 @@ defaultproperties
 	 SlideFriction=1.100000
      SlideCooldownTime=0.600000
 	 SlidePower=300.000000
+	 SlideAnims(0)="SlideF"
+	 SlideAnims(1)="SlideF"
+	 SlideAnims(2)="SlideL"
+	 SlideAnims(3)="SlideR"
+	 SlideStartAnims(0)="SlideFStart"
+	 SlideStartAnims(1)="SlideFStart"
+	 SlideStartAnims(2)="SlideLStart"
+	 SlideStartAnims(3)="SlideRStart"
+	 SlideEndAnims(0)="SlideFEnd"
+	 SlideEndAnims(1)="SlideFEnd"
+	 SlideEndAnims(2)="SlideLEnd"
+	 SlideEndAnims(3)="SlideRSEnd"
 }

--- a/BCoreProV55/Classes/BCSprintControl.uc
+++ b/BCoreProV55/Classes/BCSprintControl.uc
@@ -528,7 +528,6 @@ function StartSlide()
     {
 		DelayRecharge();
 		StopSprint();
-		//SlideCooldownTime = default.SlideCooldownTime * FClamp(Instigator.GroundSpeed / 440.0, 0.5, 2.0); //Do we need this?
 		SlideVelocity = Instigator.Velocity * 0.5 + LastFallingVelocity * 0.5; //Blend current velocity with last falling velocity
 		SlideVelocity += Normal(SlideVelocity) * FMax(SlidePower*0.5,SlidePower * (Stamina / MaxStamina));
 		// Clamp slide velocity to max speed

--- a/BCoreProV55/Classes/BC_GUICheckList.uc
+++ b/BCoreProV55/Classes/BC_GUICheckList.uc
@@ -103,6 +103,26 @@ function ToggleChecked (int i)
 	LastCheckChanged = i;
 }
 
+function bool IsChecked(int Index)
+{
+    if (Index >= 0 && Index < Checks.Length)
+        return bool(Checks[Index]);
+    return false; // Return false if the index is out of bounds
+}
+
+function int FindItem(string ItemName)
+{
+    local int i;
+
+    for (i = 0; i < Elements.Length; i++)
+    {
+        if (Elements[i].Item == ItemName)
+            return i; // Return the index if the item is found
+    }
+
+    return -1; // Return -1 if the item is not found
+}
+
 function bool CursorOverCheck()
 {
 	if (Controller.MouseX <= ClientBounds[0] + ItemHeight)

--- a/BCoreProV55/Classes/BC_GameStyle_Config.uc
+++ b/BCoreProV55/Classes/BC_GameStyle_Config.uc
@@ -44,6 +44,7 @@ var() config int			PlayerShieldMax;        // maximum armor the player can have
 var() config bool			bPlayerDeceleration;		// Decel mechanics when stopping
 var() config bool			bAllowDodging;			    // Disables dodging.
 var() config bool			bAllowDoubleJump;	        // Disables double jump.
+var() config bool			bAllowCrouchSliding;		// Allows crouch sliding, which is a sprinting mechanic that allows players to slide while crouching.
 var() config float			PlayerStrafeScale;
 var() config float			PlayerBackpedalScale;
 var() config float			PlayerGroundSpeed;
@@ -95,6 +96,7 @@ static protected function FillReplicationInfo(BallisticReplicationInfo rep)
 	rep.bPlayerDeceleration			= default.bPlayerDeceleration;
 	rep.bAllowDodging				= default.bAllowDodging;
 	rep.bAllowDoubleJump			= default.bAllowDoubleJump;
+	rep.bAllowCrouchSliding			= default.bAllowCrouchSliding;
     rep.PlayerStrafeScale 			= default.PlayerStrafeScale;
 	rep.PlayerBackpedalScale 		= default.PlayerBackpedalScale;
 	rep.PlayerGroundSpeed 			= default.PlayerGroundSpeed;

--- a/BCoreProV55/Classes/BC_GameStyle_Config.uc
+++ b/BCoreProV55/Classes/BC_GameStyle_Config.uc
@@ -59,6 +59,7 @@ var() config float			PlayerDodgeZ;
 var() config bool			bEnableSprint;
 var() config int			StaminaChargeRate;
 var() config int			StaminaDrainRate;
+var() config float			StaminaRechargeDelay; // Delay before stamina starts to recharge
 var() config float			SprintSpeedFactor;
 var() config float			JumpDrain;
 
@@ -106,6 +107,7 @@ static protected function FillReplicationInfo(BallisticReplicationInfo rep)
 	rep.bEnableSprint				= default.bEnableSprint;
 	rep.StaminaChargeRate			= default.StaminaChargeRate;
 	rep.StaminaDrainRate 			= default.StaminaDrainRate;
+	rep.StaminaRechargeDelay		= default.StaminaRechargeDelay;
 	rep.SprintSpeedFactor 			= default.SprintSpeedFactor;
 	rep.JumpDrain 					= default.JumpDrain;
 

--- a/BCoreProV55/Classes/BC_GameStyle_Fixed.uc
+++ b/BCoreProV55/Classes/BC_GameStyle_Fixed.uc
@@ -57,6 +57,7 @@ var() float			PlayerDodgeZ;
 var() bool			bEnableSprint;
 var() int			StaminaChargeRate;
 var() int			StaminaDrainRate;
+var() float			StaminaRechargeDelay;
 var() float			SprintSpeedFactor;
 var() float			JumpDrain;
 
@@ -102,6 +103,7 @@ static protected function FillReplicationInfo(BallisticReplicationInfo rep)
 	rep.bEnableSprint				= default.bEnableSprint;
 	rep.StaminaChargeRate			= default.StaminaChargeRate;
 	rep.StaminaDrainRate 			= default.StaminaDrainRate;
+	rep.StaminaRechargeDelay 		= default.StaminaRechargeDelay;
 	rep.SprintSpeedFactor 			= default.SprintSpeedFactor;
 	rep.JumpDrain					= default.JumpDrain;
 

--- a/BCoreProV55/Classes/BC_GameStyle_Fixed.uc
+++ b/BCoreProV55/Classes/BC_GameStyle_Fixed.uc
@@ -42,6 +42,7 @@ var() int			PlayerShieldMax;        // maximum armor the player can have
 var() bool			bPlayerDeceleration;		// Decel mechanics when stopping
 var() bool			bAllowDodging;			    // Disables dodging.
 var() bool			bAllowDoubleJump;	        // Disables double jump.
+var() bool			bAllowCrouchSliding;		// Allows crouch sliding, which is a sprinting mechanic that allows players to slide while crouching.
 var() float			PlayerStrafeScale;
 var() float			PlayerBackpedalScale;
 var() float			PlayerGroundSpeed;
@@ -91,6 +92,7 @@ static protected function FillReplicationInfo(BallisticReplicationInfo rep)
 	rep.bPlayerDeceleration			= default.bPlayerDeceleration;
 	rep.bAllowDodging				= default.bAllowDodging;
 	rep.bAllowDoubleJump			= default.bAllowDoubleJump;
+	rep.bAllowCrouchSliding			= default.bAllowCrouchSliding;
     rep.PlayerStrafeScale 			= default.PlayerStrafeScale;
 	rep.PlayerBackpedalScale 		= default.PlayerBackpedalScale;
 	rep.PlayerGroundSpeed 			= default.PlayerGroundSpeed;

--- a/BCoreProV55/Classes/BC_MotionBlurActor.uc
+++ b/BCoreProV55/Classes/BC_MotionBlurActor.uc
@@ -63,6 +63,9 @@ simulated function StartBlur()
 	if (PC == None)
 		return;
 
+	if(PC.bGodMode)
+		return;
+
 	// To avoid conflict problems, we'll hijack any existing 'MotionBlur' rather than spawning a new one...
 	for (i=0;i<PC.CameraEffects.length;i++)
 		if (MotionBlur(PC.CameraEffects[i]) != None)	{
@@ -84,7 +87,7 @@ simulated function StartBlur()
 
 simulated event Tick(float DT)
 {
-	if (PC == None)
+	if (PC == None || PC.bGodMode)
 	{
 		Destroy();
 		return;

--- a/BCoreProV55/Classes/BC_WeaponInfoCache.uc
+++ b/BCoreProV55/Classes/BC_WeaponInfoCache.uc
@@ -60,6 +60,7 @@ static function bool FindWeaponInfo(string CN, out WeaponInfo WI, optional out i
 // Fast shotcut to use FindWeaponInfo() and automatically AddWeaponInfoName() if needed
 static function WeaponInfo AutoWeaponInfo(string WeapClassName, optional out int i)
 {
+	Log("AutoWeaponInfo called with ClassStr: " $ WeapClassName);
 	return CurrentCache().static.AutoWeaponInfo(WeapClassName, i);
 }
 

--- a/BCoreProV55/Classes/BUtil.uc
+++ b/BCoreProV55/Classes/BUtil.uc
@@ -191,7 +191,7 @@ static final function Vector VSmerp(float Alpha, Vector A, Vector B)
 	V.Z = Smerp(Alpha, A.Z, B.Z);
 	return V;
 }
-// Rotator Smerp
+// Rotator Lerp
 static final function Rotator RLerp (float Alpha, Rotator A, Rotator B, optional bool bClampRange)
 {
 	local Rotator R;

--- a/BCoreProV55/Classes/BallisticMachinegun.uc
+++ b/BCoreProV55/Classes/BallisticMachinegun.uc
@@ -109,13 +109,6 @@ simulated function SetBeltVisibility(int Amount)
 	else
 		SetBoneScale(0, 1.0, BeltBones[0]);
 }
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2 && HasAnim('ReloadEndCock'))
-		PlayAnim('ReloadEndCock', CockAnimRate, 0.2);
-	else
-		PlayAnim(CockAnim, CockAnimRate, 0.2);
-}
 
 // Run to give hand opportinity to go to stand mode handle instead of playing to end of normal reload anim
 simulated function Notify_M353GoToHandle()

--- a/BCoreProV55/Classes/BallisticMeleeFire.uc
+++ b/BCoreProV55/Classes/BallisticMeleeFire.uc
@@ -30,9 +30,11 @@ struct SwipeHit
 	var() Vector	HitDir;		// Direction of the trace
 };
 var()   array<SwipePoint>	SwipePoints;	// The rotational offset points used to determin the path of the swipe
-var()   int					WallHitPoint;	// Which of the points should be sued for wall hits
-var()   int					NumSwipePoints;	// Which of the points should be sued for wall hits
+var()   int					WallHitPoint;	// Which of the points should be used for wall hits
+var()   int					NumSwipePoints;	// Which of the points should be used for wall hits
 var     array<SwipeHit>		SwipeHits;		// Temporary(per fire) record of hits. For comparing multiple hits on same targets
+var() 	Vector				TraceExtent;	// The extent of the trace used to find actors. This is used to determine the size of the trace
+//var()   float				WideDamageMinHitAngle;	// Minimum angle to hit a target with wide damage
 
 var	    float	            HoldStartTime;		//Used if this weapon's mode is 2, which means it's being used for its ModeDoFire function.
 var()   float               MaxBonusHoldTime;	//Max hold time for bonus damage
@@ -142,7 +144,7 @@ function DoFireEffect()
 
     if (Level.NetMode == NM_DedicatedServer)
         BW.RewindCollisions();
-
+ 
 	// Do trace for each point
 	for	(i=0; i<NumSwipePoints; i++)
 	{
@@ -152,9 +154,11 @@ function DoFireEffect()
 		MeleeDoTrace(StartTrace, PointAim, i==WallHitPoint, SwipePoints[i].Weight);
 	}
 
+	//MeleeDoTrace(StartTrace, Aim);
+
     if (Level.NetMode == NM_DedicatedServer)
         BW.RestoreCollisions();
-
+ 
 	// Do damage for each victim
 	for (i=0; i<SwipeHits.length; i++)
 	{
@@ -173,6 +177,103 @@ simulated function SendFireEffect(Actor Other, vector HitLocation, vector HitNor
 		BallisticAttachment(Weapon.ThirdPersonActor).MeleeUpdateHit(Other, HitLocation, HitNormal, Surf);
 	else Super.SendFireEffect(Other, HitLocation, HitNormal, Surf, WaterHitLoc);
 }
+/* 
+function MeleeDoTrace(Vector InitialStart, Rotator Dir)
+{
+    local Vector End, X, HitLocation, HitNormal, Start, VictimsDir;
+    local Actor HitActor, LastHitActor;
+    local Material HitMaterial;
+    local Pawn Victims;
+    local float DiffAngle, VictimDist, Dist;
+    local bool bHitWall;
+
+	Dist = TraceRange.Min + FRand() * (TraceRange.Max - TraceRange.Min);
+
+	Start = InitialStart;
+	X = Vector(Dir);
+	End = Start + X * Dist;
+
+    // Handle pawns first (WideDamageMinHitAngle logic)
+    if (WideDamageMinHitAngle > 0)
+    {
+        foreach Weapon.VisibleCollidingActors(class'Pawn', Victims, Dist, Start)
+        {
+            if (Victims.Health <= 0 || Victims == Instigator)
+                continue;
+
+            VictimDist = VSize(Instigator.Location - Victims.Location);
+			Level.Game.Broadcast(Instigator,"VictimDist: "$VictimDist);
+            if (VictimDist > (Dist * 1.1 + Victims.CollisionRadius))
+                continue;
+
+            VictimsDir = Normal(Victims.Location - Instigator.Location);
+			DiffAngle = Acos(X dot VictimsDir) * (180 / Pi); //Convert to degrees
+			Level.Game.Broadcast(Instigator,"DiffAngle: "$DiffAngle);
+            if (DiffAngle <= WideDamageMinHitAngle)
+            {
+				Level.Game.Broadcast(Instigator,"DiffAngle smaller than WideDamageMinHitAngle: "$DiffAngle);
+				HitLocation = Start + (X * VSize(Victims.Location - Start)); //Like trace but without actual trace
+                OnTraceHit(Victims, HitLocation, Start, X, 0, 0, 0);
+            }
+        }
+    }
+
+    // Handle world geometry, vehicles, and other actors
+    while (Dist > 0)
+    {
+        // Perform the trace
+        HitActor = Trace(HitLocation, HitNormal, End, Start, true, , HitMaterial);
+        Dist -= VSize(HitLocation - Start);
+
+        if (HitActor != None)
+        {
+            // Handle water volumes or fluid surfaces
+            if ((FluidSurfaceInfo(HitActor) != None) || ((PhysicsVolume(HitActor) != None) && PhysicsVolume(HitActor).bWaterVolume))
+            {
+                Start = HitLocation;
+                End = Start + X * Dist;
+                continue;
+            }
+
+            // Handle vehicles
+            if (Vehicle(HitActor) != None)
+            {
+                OnTraceHit(HitActor, HitLocation, Start, X, 0, 0, 0);
+                bHitWall = ImpactEffect(HitLocation, HitNormal, HitMaterial, HitActor, vect(0, 0, 0));
+                break;
+            }
+
+            // Handle world geometry
+            if (HitActor.bWorldGeometry || Mover(HitActor) != None)
+            {
+                bHitWall = ImpactEffect(HitLocation, HitNormal, HitMaterial, HitActor, vect(0, 0, 0));
+                break;
+            }
+
+            // Handle other actors
+            if (HitActor.bCanBeDamaged && HitActor != Instigator && HitActor != LastHitActor)
+            {
+                OnTraceHit(HitActor, HitLocation, Start, X, 0, 0, 0);
+                LastHitActor = HitActor;
+            }
+
+            // Update trace start and end points for multi-hit handling
+            Start = HitLocation + (X * HitActor.CollisionRadius * 2);
+            End = Start + X * Dist;
+        }
+        else
+        {
+            break;
+        }
+    }
+
+    // Handle cases where no wall was hit
+    if (!bHitWall)
+    {
+        NoHitEffect(X, Start, End, vect(0, 0, 0));
+    }
+}
+*/
 
 // Do the trace to find out where bullet really goes
 function MeleeDoTrace (Vector InitialStart, Rotator Dir, bool bWallHitter, int Weight)
@@ -196,7 +297,7 @@ function MeleeDoTrace (Vector InitialStart, Rotator Dir, bool bWallHitter, int W
 	while (Dist > 0)		// Loop traces in case we need to go through stuff
 	{
 		// Do the trace
-		Other = Trace (HitLocation, HitNormal, End, Start, true, , HitMaterial);
+		Other = Trace(HitLocation, HitNormal, End, Start, true, TraceExtent, HitMaterial);
 		Dist -= VSize(HitLocation - Start);
 		if (Level.NetMode == NM_Client && (Other.Role != Role_Authority || Other.bWorldGeometry))
 			break;
@@ -460,6 +561,8 @@ defaultproperties
 	SwipePoints(4)=(Weight=2,offset=(Yaw=-2560))
 	WallHitPoint=2
 	NumSwipePoints=5
+	TraceExtent=(X=0.000000,Y=15.000000,Z=15.000000) // The extent of the trace used to find actors
+	//WideDamageMinHitAngle=25.000000 //2560*360/65536 = 14.0625 degrees, let's round up to 15 degrees
 	WallPenetrationForce=0
 
 	MaxBonusHoldTime=1.500000

--- a/BCoreProV55/Classes/BallisticReplicationInfo.uc
+++ b/BCoreProV55/Classes/BallisticReplicationInfo.uc
@@ -83,6 +83,11 @@ var() config float			SprintSpeedFactor;
 var() config float			JumpDrain;
 
 //=============================================================================
+// CROUCH SLIDING
+//=============================================================================
+var() config bool					bAllowCrouchSliding;		// Allows crouch sliding, which is a sprinting mechanic that allows players to slide while crouching.
+
+//=============================================================================
 // HEALTH/ARMOR - NO REP
 //=============================================================================
 var bool					bHealthRegeneration;
@@ -137,6 +142,7 @@ var struct MoveRep
 	var bool					bPlayerDeceleration;		// Decel mechanics when stopping
 	var bool					bAllowDodging;				// Enables dodging.
 	var bool					bAllowDoubleJump;			// Enables double jump.
+	var() config bool			bAllowCrouchSliding;		// Allows crouch sliding, which is a sprinting mechanic that allows players to slide while crouching.
 	var float					PlayerWalkSpeedFactor;
 	var float					PlayerCrouchSpeedFactor;
 	var float					PlayerAnimationGroundSpeed;
@@ -199,6 +205,7 @@ final function BindToReplication()
 	MRep.bPlayerDeceleration			= bPlayerDeceleration;
     MRep.bAllowDodging		            = bAllowDodging;
 	MRep.bAllowDoubleJump				= bAllowDoubleJump;
+	MRep.bAllowCrouchSliding			= bAllowCrouchSliding;
     MRep.PlayerWalkSpeedFactor      	= PlayerWalkSpeedFactor;
 	MRep.PlayerCrouchSpeedFactor      	= PlayerCrouchSpeedFactor;
 	MRep.PlayerAnimationGroundSpeed		= PlayerAnimationGroundSpeed;
@@ -264,6 +271,7 @@ simulated final function BindFromReplication()
 	bPlayerDeceleration				= MRep.bPlayerDeceleration;
     bAllowDodging		            = MRep.bAllowDodging;
 	bAllowDoubleJump				= MRep.bAllowDoubleJump;
+	bAllowCrouchSliding				= MRep.bAllowCrouchSliding;
     PlayerWalkSpeedFactor      		= MRep.PlayerWalkSpeedFactor;
 	PlayerCrouchSpeedFactor       	= MRep.PlayerCrouchSpeedFactor;
 	PlayerAnimationGroundSpeed		= MRep.PlayerAnimationGroundSpeed;
@@ -313,6 +321,7 @@ simulated final function BindDefaults()
 	class.default.bPlayerDeceleration			= bPlayerDeceleration;
     class.default.bAllowDodging		            = bAllowDodging;
 	class.default.bAllowDoubleJump				= bAllowDoubleJump;
+	class.default.bAllowCrouchSliding			= bAllowCrouchSliding;
     class.default.PlayerWalkSpeedFactor      	= PlayerWalkSpeedFactor;
 	class.default.PlayerCrouchSpeedFactor       = PlayerCrouchSpeedFactor;
 	class.default.PlayerAnimationGroundSpeed	= PlayerAnimationGroundSpeed;

--- a/BCoreProV55/Classes/BallisticReplicationInfo.uc
+++ b/BCoreProV55/Classes/BallisticReplicationInfo.uc
@@ -78,6 +78,7 @@ var float					PlayerDodgeZ;
 var() config bool			bEnableSprint;
 var() config int			StaminaChargeRate;
 var() config int			StaminaDrainRate;
+var() config float			StaminaRechargeDelay;
 var() config float			SprintSpeedFactor;
 var() config float			JumpDrain;
 
@@ -154,6 +155,7 @@ var struct SprintRep
 	var() config bool			bEnableSprint;
 	var() config int			StaminaChargeRate;
 	var() config int			StaminaDrainRate;
+	var() config float 			StaminaRechargeDelay;
 	var() config float			SprintSpeedFactor;
 	var() config float			JumpDrain;
 } SRep;
@@ -212,8 +214,10 @@ final function BindToReplication()
 	SRep.bEnableSprint					= true;
 	SRep.StaminaChargeRate				= StaminaChargeRate;
 	SRep.StaminaDrainRate				= StaminaDrainRate;
+	SRep.StaminaRechargeDelay			= StaminaRechargeDelay;
     SRep.SprintSpeedFactor				= SprintSpeedFactor;
 	SRep.JumpDrain						= JumpDrain;
+
 }
 
 // Set all defaults to match server vars here
@@ -275,6 +279,7 @@ simulated final function BindFromReplication()
 	bEnableSprint					= true;
 	StaminaChargeRate				= SRep.StaminaChargeRate;
 	StaminaDrainRate				= SRep.StaminaDrainRate;
+	StaminaRechargeDelay			= SRep.StaminaRechargeDelay;
     SprintSpeedFactor				= SRep.SprintSpeedFactor;
 	JumpDrain					= SRep.JumpDrain;
 }
@@ -323,6 +328,7 @@ simulated final function BindDefaults()
 	class.default.bEnableSprint					= true;
 	class.default.StaminaChargeRate				= StaminaChargeRate;
 	class.default.StaminaDrainRate				= StaminaDrainRate;
+	class.default.StaminaRechargeDelay			= StaminaRechargeDelay;
     class.default.SprintSpeedFactor				= SprintSpeedFactor;
 	class.default.JumpDrain				= JumpDrain;
 

--- a/BCoreProV55/Classes/BallisticWeapon.uc
+++ b/BCoreProV55/Classes/BallisticWeapon.uc
@@ -3676,7 +3676,7 @@ function bool CanAttack(Actor Other)
 	}
 
 	// Skilled bots can conserve ammo by not firing when the spread is too high
-	if ((Rand(6) < AIController(Instigator.Controller).Skill) && !RcComponent.BotShouldFire(Dist) )
+	if (AIController(Instigator.Controller) != None && (Rand(6) < AIController(Instigator.Controller).Skill) && !RcComponent.BotShouldFire(Dist) )
 		return false;
 
     for (m = 0; m < NUM_FIRE_MODES; m++)

--- a/BCoreProV55/Classes/BallisticWeapon.uc
+++ b/BCoreProV55/Classes/BallisticWeapon.uc
@@ -311,6 +311,7 @@ var() float 				ScopeXScale;			// Corrects for legacy scopes made for full-scree
 var() float					ScopeScale;				// General scaler for scope texture draw
 var() name					ZoomInAnim;				// Anim to play for raising weapon to view through Scope or sights
 var() name					ZoomOutAnim;			// Anim to play when lowering weapon after viewing through scope or sights
+var() globalconfig float 	ZoomTimeMod;			// Multiplier for sighting/zooming
 var() BUtil.FullSound		ZoomInSound;			// Sound when zooming in
 var() BUtil.FullSound		ZoomOutSound;			// Sound when zooming out
 var() float					SightDisplayFOV;		// DisplayFOV for drawing gun in scope/sight view. Default property setting is now ignored.
@@ -557,6 +558,8 @@ simulated function PostBeginPlay()
 	CreateAimComponent();
 
 	OnMeshChanged();
+	
+
 
 	if (bUseBigIcon)
 	{
@@ -668,6 +671,7 @@ simulated function PostNetBeginPlay()
     bDeferInitialSwitch = bServerDeferInitialSwitch;
 
 	SightBobScale *= class'BallisticGameStyles'.static.GetReplicatedStyle().default.SightBobScale;
+
 }
 
 simulated function CheckSetBurstMode()
@@ -817,8 +821,8 @@ simulated function OnWeaponParamsChanged()
 	
     assert(WeaponParams != None);
 
-	SightingTime 				= WeaponParams.SightingTime;
-	//default.SightingTime 		= WeaponParams.SightingTime;
+	SightingTime 				= WeaponParams.SightingTime / ZoomTimeMod;
+	//default.SightingTime 		= WeaponParams.SightingTime / ZoomTimeMod;
 
 	MagAmmo 					= WeaponParams.MagAmmo;
 	default.MagAmmo				= WeaponParams.MagAmmo;
@@ -836,10 +840,22 @@ simulated function OnWeaponParamsChanged()
 	//default.ReloadAnimRate				= WeaponParams.ReloadAnimRate;
 	ReloadAnimRate *= class'BallisticReplicationInfo'.default.ReloadScale;
 	default.ReloadAnimRate *= class'BallisticReplicationInfo'.default.ReloadScale;
-	
-	CockAnimRate 					= WeaponParams.CockAnimRate;
-	default.CockAnimRate				= WeaponParams.CockAnimRate;
-	
+
+	StartShovelAnimRate *= class'BallisticReplicationInfo'.default.ReloadScale;
+	EndShovelAnimRate *= class'BallisticReplicationInfo'.default.ReloadScale;
+
+	CockAnimRate = WeaponParams.CockAnimRate;
+	default.CockAnimRate = WeaponParams.CockAnimRate;
+
+	if (Level.GRI != None && Level.GRI.bFastWeaponSwitching)
+	{
+		BringUpTime = 0.1;
+		default.BringUpTime = 0.1;
+		PutDownTime = 0.1;
+		default.PutDownTime = 0.1;
+		CockSelectAnimRate = 3.0; 
+		CockingBringUpTime = 0.1;
+	}
 	if (PlayerController(Instigator.Controller) != None)
 		bNeedCock						= WeaponParams.bNeedCock;
 
@@ -1194,6 +1210,7 @@ simulated event AnimEnd (int Channel)
 
 simulated function float GetModifiedJumpZ(Pawn P)
 {
+	//log("GetModifiedJumpZ: " $ P.JumpZ * PlayerJumpFactor);
 	return P.JumpZ * PlayerJumpFactor;
 }
 
@@ -1294,8 +1311,13 @@ simulated event WeaponTick(float DT)
 
 	AimComponent.UpdateDisplacements(DT);
 
-	TickSighting(DT);
+	if(AIController(Instigator.Controller) == None)
+		TickSighting(DT);
 	TickFireCounter(DT);
+
+	// Ensure SprintControl is linked
+    if (SprintControl == None)
+        LinkSprintControl();
 	
 	//FIXME. This shouldn't be necessary at all.
 	if (bPreventReload && !IsFiring())
@@ -1556,13 +1578,21 @@ simulated function PlayShovelLoop()
 
 simulated function PlayCocking(optional byte Type)
 {
-	if (Type == 2 && HasAnim(CockAnimPostReload))
-		SafePlayAnim(CockAnimPostReload, CockAnimRate, 0.2, , "RELOAD");
-	else
-		SafePlayAnim(CockAnim, CockAnimRate, 0.2, , "RELOAD");
+    local float AdjustedCockAnimRate;
 
-	if (SightingState != SS_None)
-		TemporaryScopeDown(default.SightingTime);
+    // Adjust cock animation rate only during reloading
+    if (ReloadState != RS_None && ReloadState != RS_Cocking)
+        AdjustedCockAnimRate = CockAnimRate * class'BallisticReplicationInfo'.default.ReloadScale;
+    else
+        AdjustedCockAnimRate = CockAnimRate; // Use default rate for firing
+
+    if (Type == 2 && HasAnim(CockAnimPostReload))
+        SafePlayAnim(CockAnimPostReload, AdjustedCockAnimRate, 0.2, , "RELOAD");
+    else
+        SafePlayAnim(CockAnim, AdjustedCockAnimRate, 0.2, , "RELOAD");
+
+    if (SightingState != SS_None)
+        TemporaryScopeDown(default.SightingTime);
 }
 
 //================================================================================
@@ -1925,7 +1955,7 @@ simulated final function StopScopeView(optional bool bNoAnim)
 simulated function PlayScopeDown(optional bool bNoAnim)
 {
 	if (!bNoAnim && HasAnim(ZoomOutAnim))
-	    SafePlayAnim(ZoomOutAnim, 1.0);
+	    SafePlayAnim(ZoomOutAnim, ZoomTimeMod);
 	else if (SightingState == SS_Active || SightingState == SS_Raising)
 		SightingState = SS_Lowering;
 
@@ -1939,7 +1969,7 @@ simulated function PlayScopeDown(optional bool bNoAnim)
 simulated function PlayScopeUp()
 {
 	if (HasAnim(ZoomInAnim))
-	    SafePlayAnim(ZoomInAnim, 1.0);
+	    SafePlayAnim(ZoomInAnim, ZoomTimeMod);
 	else
 		SightingState = SS_Raising;
 	if(ZoomType == ZT_Irons)
@@ -2106,6 +2136,9 @@ simulated function StartScopeZoom()
 
 	if (ZoomInSound.Sound != None)	
 		class'BUtil'.static.PlayFullSound(self, ZoomInSound);
+
+	if(!CanUseSights())
+		return;
 
     PlayerZoom(PC);
 }
@@ -2534,6 +2567,9 @@ simulated function PositionSights()
 
 	//bots can't use sights
 	PC=PlayerController(InstigatorController);
+
+	if (PC == None)
+		return;
 
 	if (SightBone != '')
 		SightPos = GetBoneCoords(SightBone).Origin - Location;
@@ -3331,7 +3367,7 @@ static function class<Pickup> RecommendAmmoPickup(int Mode)
 simulated function BringUp(optional Weapon PrevWeapon)
 {
 	local int mode, i;
-	
+
 	// Set ambient sound when gun is held
 	if (UsedAmbientSound != None)
 		AmbientSound = UsedAmbientSound;
@@ -3356,7 +3392,7 @@ simulated function BringUp(optional Weapon PrevWeapon)
 	if (PlayerSpeedFactor != default.PlayerSpeedFactor)
 		PlayerSpeedFactor = default.PlayerSpeedFactor;
 
-	LinkSprintControl();
+	//LinkSprintControl();
 
 	AimComponent.OnWeaponSelected();
 
@@ -3425,9 +3461,9 @@ simulated function BringUp(optional Weapon PrevWeapon)
 		BringUpTime = CockingBringUpTime;
 	else BringUpTime = default.BringUpTime;
 	
-    if (!IsInState('PendingClientWeaponSet'))
-    	SetTimer(BringUpTime, false);
-    else bPendingBringupTimer = True;
+	if (!IsInState('PendingClientWeaponSet'))
+		SetTimer(BringUpTime, false);
+	else bPendingBringupTimer = True;
 		
     for (Mode = 0; Mode < NUM_FIRE_MODES; Mode++)
 	{
@@ -3443,6 +3479,7 @@ simulated function BringUp(optional Weapon PrevWeapon)
 		OldWeapon = PrevWeapon;
 	else
 		OldWeapon = None;
+
 }
 
 //Azarael - Anti TCC compatible weapon zoom.
@@ -3491,8 +3528,8 @@ simulated function bool PutDown()
 			PlayerController(Instigator.Controller).MyHud.bCrosshairShow = PlayerController(Instigator.Controller).MyHud.default.bCrosshairShow;
 		if (PutDownSound.Sound != None)
 			class'BUtil'.static.PlayFullSound(self, PutDownSound);
-        SetTimer(PutDownTime, false);
-    }
+		SetTimer(PutDownTime, false);
+	}
     for (Mode = 0; Mode < NUM_FIRE_MODES; Mode++)
     {
 		if (FireMode[Mode]==None)
@@ -3506,7 +3543,7 @@ simulated function bool PutDown()
     
     if(PlayerController(Instigator.Controller) != None)
 		PlayerController(Instigator.Controller).bZooming = False;
-		
+
     return true; // return false if preventing weapon switch
 }
 
@@ -3984,6 +4021,7 @@ simulated function ClientWeaponSet(bool bPossiblySwitch)
             Instigator.Weapon.PutDown();
         }
     }
+
 }
 
 state PendingClientWeaponSet
@@ -5720,6 +5758,7 @@ defaultproperties
 	 MagAmmo=30
 	 
 	 CockAnim="Cock"
+	 CockAnimPostReload="ReloadEndCock"
 	 CockAnimRate=1.000000
      CockSelectAnim="PulloutFancy"
 	 CockSelectAnimRate=1.000000
@@ -5770,6 +5809,7 @@ defaultproperties
      MaxZoom=2.000000
      ZoomStages=2
 	 SightBobScale=0.15f
+	 ZoomTimeMod=1.000000
 	 
      SMuzzleFlashOffset=(X=25.000000,Z=-15.000000)
      MagEmptyColor=(B=50,G=50,R=255,A=150)

--- a/BCoreProV55/Classes/GameStyle_Classic.uc
+++ b/BCoreProV55/Classes/GameStyle_Classic.uc
@@ -30,6 +30,7 @@ defaultproperties
 	bPlayerDeceleration=False
 	bAllowDodging=True
 	bAllowDoubleJump=True
+	bAllowCrouchSliding=True 
 	// this value is a fallback which is overridden by weapon ADS move factor,
 	// and should be the highest possible ADS movement multiplier for your style
     PlayerWalkSpeedFactor=0.5

--- a/BCoreProV55/Classes/GameStyle_Classic.uc
+++ b/BCoreProV55/Classes/GameStyle_Classic.uc
@@ -47,6 +47,7 @@ defaultproperties
 	bEnableSprint=true
 	StaminaChargeRate=20
 	StaminaDrainRate=20
+	StaminaRechargeDelay=1.5
 	SprintSpeedFactor=1.35f
 	JumpDrain=2
 

--- a/BCoreProV55/Classes/GameStyle_Pro.uc
+++ b/BCoreProV55/Classes/GameStyle_Pro.uc
@@ -56,6 +56,7 @@ defaultproperties
 	StaminaChargeRate=15
 	StaminaDrainRate=10
 	SprintSpeedFactor=1.4f
+	StaminaRechargeDelay=1.5
 	JumpDrain=5
 
     HealthKillReward=25

--- a/BCoreProV55/Classes/GameStyle_Pro.uc
+++ b/BCoreProV55/Classes/GameStyle_Pro.uc
@@ -38,6 +38,7 @@ defaultproperties
 	bPlayerDeceleration=False
 	bAllowDodging=True
 	bAllowDoubleJump=True
+	bAllowCrouchSliding=True 
 	// this value is a fallback which is overridden by weapon ADS move factor,
 	// and should be the highest possible ADS movement multiplier for your style
     PlayerWalkSpeedFactor=0.9

--- a/BCoreProV55/Classes/GameStyle_Realism.uc
+++ b/BCoreProV55/Classes/GameStyle_Realism.uc
@@ -52,6 +52,7 @@ defaultproperties
 	StaminaChargeRate=10
 	StaminaDrainRate=10
 	SprintSpeedFactor=1.4f
+	StaminaRechargeDelay=1.5
 	JumpDrain=2
 
 	HealthKillReward=0

--- a/BCoreProV55/Classes/GameStyle_Realism.uc
+++ b/BCoreProV55/Classes/GameStyle_Realism.uc
@@ -35,6 +35,7 @@ defaultproperties
 	bPlayerDeceleration=True
 	bAllowDodging=True
 	bAllowDoubleJump=False
+	bAllowCrouchSliding=True 
 	PlayerStrafeScale=1
 	PlayerBackpedalScale=1
 	PlayerGroundSpeed=200

--- a/BCoreProV55/Classes/GameStyle_Tactical.uc
+++ b/BCoreProV55/Classes/GameStyle_Tactical.uc
@@ -43,6 +43,7 @@ defaultproperties
 	bPlayerDeceleration=True
 	bAllowDodging=True
 	bAllowDoubleJump=False
+	bAllowCrouchSliding=True 
 	PlayerStrafeScale=1
 	PlayerBackpedalScale=1
 	PlayerGroundSpeed=210

--- a/BCoreProV55/Classes/GameStyle_Tactical.uc
+++ b/BCoreProV55/Classes/GameStyle_Tactical.uc
@@ -59,6 +59,7 @@ defaultproperties
 	bEnableSprint=True
 	StaminaChargeRate=25
 	StaminaDrainRate=20
+	StaminaRechargeDelay=1.0
 	SprintSpeedFactor=1.4f
 	JumpDrain=10
 

--- a/BWBPAirstrikesPro/Classes/TargetDesignator.uc
+++ b/BWBPAirstrikesPro/Classes/TargetDesignator.uc
@@ -384,6 +384,7 @@ defaultproperties
     ZoomOutAnim="Lower"
     ScopeViewTex=Texture'BWBP_OP_Tex.Designator.DesignatorScreen'
     FullZoomFOV=20.000000
+	MaxZoom=4.000000
     bNoCrosshairInScope=True
     bAimDisabled=True
     ParamsClasses(0)=Class'TargetDesignatorWeaponParams'

--- a/BWBP_APC_Pro/Classes/FM14Shotgun.uc
+++ b/BWBP_APC_Pro/Classes/FM14Shotgun.uc
@@ -276,14 +276,6 @@ function float SuggestDefenseStyle()
 
 // End AI Stuff =====
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2 && HasAnim(CockAnimPostReload))
-		SafePlayAnim(CockAnimPostReload, CockAnimRate, 0.2, , "RELOAD");
-	else
-		SafePlayAnim(CockAnim, CockAnimRate, 0.2, , "RELOAD");
-}
-
 // Animation notify for when cocking action starts. Used to time sounds
 simulated function Notify_CockAimed()
 {

--- a/BWBP_APC_Pro/Classes/HB4GrenadeBlaster.uc
+++ b/BWBP_APC_Pro/Classes/HB4GrenadeBlaster.uc
@@ -35,14 +35,6 @@ simulated function BringUp(optional Weapon PrevWeapon)
 	BringUpTime = default.BringUpTime;
 }
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2)
-		PlayAnim('ReloadEndCock', CockAnimRate, 0.2);
-	else
-		PlayAnim(CockAnim, CockAnimRate, 0.2);
-}
-
 simulated function float ChargeBar()
 {
 	if (level.TimeSeconds >= FireMode[1].NextFireTime)

--- a/BWBP_APC_Pro/Classes/HKMKSpecPistol.uc
+++ b/BWBP_APC_Pro/Classes/HKMKSpecPistol.uc
@@ -290,14 +290,6 @@ simulated function OnScopeViewChanged()
 		SightOffset.Y = default.SightOffset.Y * -1;
 }
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2)
-		PlayAnim('ReloadEndCock', CockAnimRate, 0.2);
-	else
-		PlayAnim(CockAnim, CockAnimRate, 0.2);
-}
-
 exec simulated function WeaponSpecial(optional byte i)
 {
 	if (ReloadState != RS_None || SightingState != SS_None)

--- a/BWBP_APC_Pro/Classes/MJ51Carbine.uc
+++ b/BWBP_APC_Pro/Classes/MJ51Carbine.uc
@@ -177,7 +177,7 @@ simulated function LoadGrenade()
 	if (ReloadState == RS_None)
 	{
 		ReloadState = RS_GearSwitch;
-		PlayAnim(GrenadeLoadAnim, 1.1, , 0);
+		PlayAnim(GrenadeLoadAnim, ReloadAnimRate+0.1, , 0);
 	}
 }
 

--- a/BWBP_APC_Pro/Classes/PKMMachinegun.uc
+++ b/BWBP_APC_Pro/Classes/PKMMachinegun.uc
@@ -199,14 +199,6 @@ simulated function Notify_CockAfterReload()
 		PlayAnim('ReloadFinishHold', ReloadAnimRate, 0.2);
 }
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2 && HasAnim('ReloadEndCock'))
-		PlayAnim('ReloadEndCock', CockAnimRate, 0.2);
-	else
-		PlayAnim(CockAnim, CockAnimRate, 0.2);
-}
-
 simulated function bool HasAmmo()
 {
 	//First Check the magazine

--- a/BWBP_APC_Pro/Classes/R9000ERifle.uc
+++ b/BWBP_APC_Pro/Classes/R9000ERifle.uc
@@ -205,10 +205,18 @@ simulated function NewDrawWeaponInfo(Canvas C, float YPos)
 
 simulated function PlayCocking(optional byte Type)
 {
-	if (Type == 2 && HasAnim(CockAnimPostReload))
-		SafePlayAnim(CockAnimPostReload, CockAnimRate, 0.2, , "RELOAD");
-	else
-		SafePlayAnim(CockAnim, CockAnimRate, 0.2, , "RELOAD");
+    local float AdjustedCockAnimRate;
+
+    // Adjust cock animation rate only during reloading
+    if (ReloadState != RS_None && ReloadState != RS_Cocking)
+        AdjustedCockAnimRate = CockAnimRate * class'BallisticReplicationInfo'.default.ReloadScale;
+    else
+        AdjustedCockAnimRate = CockAnimRate; // Use default rate for firing
+
+    if (Type == 2 && HasAnim(CockAnimPostReload))
+        SafePlayAnim(CockAnimPostReload, AdjustedCockAnimRate, 0.2, , "RELOAD");
+    else
+        SafePlayAnim(CockAnim, AdjustedCockAnimRate, 0.2, , "RELOAD");
 
 	if (SightingState != SS_None && Type != 1)
 		TemporaryScopeDown(0.5);

--- a/BWBP_APC_Pro/Classes/SRKSubMachinegun.uc
+++ b/BWBP_APC_Pro/Classes/SRKSubMachinegun.uc
@@ -142,7 +142,7 @@ simulated function LoadGrenade()
 	if (Ammo[1].AmmoAmount < 1 || bLoaded)
 		return;
 	if (ReloadState == RS_None)
-		PlayAnim(GrenadeLoadAnim, 1.1, , 0);
+		PlayAnim(GrenadeLoadAnim, ReloadAnimRate+0.25, , 0);
 }
 
 // Notifys for greande loading sounds

--- a/BWBP_APC_Pro/Classes/TridentMachinegun.uc
+++ b/BWBP_APC_Pro/Classes/TridentMachinegun.uc
@@ -168,15 +168,6 @@ simulated function Notify_CockAfterReload()
 	else
 		PlayAnim('ReloadFinishHold', ReloadAnimRate, 0.2);
 }
-
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2 && HasAnim('ReloadEndCock'))
-		PlayAnim('ReloadEndCock', CockAnimRate, 0.2);
-	else
-		PlayAnim(CockAnim, CockAnimRate, 0.2);
-}
-
 simulated function PositionSights ()
 {
 	super.PositionSights();

--- a/BWBP_JCF_Pro/Classes/HKMKSpecPistol.uc
+++ b/BWBP_JCF_Pro/Classes/HKMKSpecPistol.uc
@@ -290,14 +290,6 @@ simulated function OnScopeViewChanged()
 		SightOffset.Y = default.SightOffset.Y * -1;
 }
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2)
-		PlayAnim('ReloadEndCock', CockAnimRate, 0.2);
-	else
-		PlayAnim(CockAnim, CockAnimRate, 0.2);
-}
-
 exec simulated function WeaponSpecial(optional byte i)
 {
 	if (ReloadState != RS_None || SightingState != SS_None)

--- a/BWBP_JCF_Pro/Classes/M7A3AssaultRifle.Uc
+++ b/BWBP_JCF_Pro/Classes/M7A3AssaultRifle.Uc
@@ -105,10 +105,18 @@ simulated function BringUp(optional Weapon PrevWeapon)
 
 simulated function PlayCocking(optional byte Type)
 {
-	if (Type == 2 && HasAnim(CockAnimPostReload))
-		SafePlayAnim(CockAnimPostReload, CockAnimRate, 0.2, , "RELOAD");
-	else
-		SafePlayAnim(CockAnim, CockAnimRate, 0.2, , "RELOAD");
+    local float AdjustedCockAnimRate;
+
+    // Adjust cock animation rate only during reloading
+    if (ReloadState != RS_None && ReloadState != RS_Cocking)
+        AdjustedCockAnimRate = CockAnimRate * class'BallisticReplicationInfo'.default.ReloadScale;
+    else
+        AdjustedCockAnimRate = CockAnimRate; // Use default rate for firing
+
+    if (Type == 2 && HasAnim(CockAnimPostReload))
+        SafePlayAnim(CockAnimPostReload, AdjustedCockAnimRate, 0.2, , "RELOAD");
+    else
+        SafePlayAnim(CockAnim, AdjustedCockAnimRate, 0.2, , "RELOAD");
 
 	if (SightingState != SS_None && Type != 1)
 		TemporaryScopeDown(0.5);

--- a/BWBP_JCF_Pro/Classes/M99Rifle.Uc
+++ b/BWBP_JCF_Pro/Classes/M99Rifle.Uc
@@ -256,10 +256,18 @@ function InitLaser(optional byte i)
 
 simulated function PlayCocking(optional byte Type)
 {
-	if (Type == 2 && HasAnim(CockAnimPostReload))
-		SafePlayAnim(CockAnimPostReload, CockAnimRate, 0.2, , "RELOAD");
-	else
-		SafePlayAnim(CockAnim, CockAnimRate, 0.2, , "RELOAD");
+    local float AdjustedCockAnimRate;
+
+    // Adjust cock animation rate only during reloading
+    if (ReloadState != RS_None && ReloadState != RS_Cocking)
+        AdjustedCockAnimRate = CockAnimRate * class'BallisticReplicationInfo'.default.ReloadScale;
+    else
+        AdjustedCockAnimRate = CockAnimRate; // Use default rate for firing
+
+    if (Type == 2 && HasAnim(CockAnimPostReload))
+        SafePlayAnim(CockAnimPostReload, AdjustedCockAnimRate, 0.2, , "RELOAD");
+    else
+        SafePlayAnim(CockAnim, AdjustedCockAnimRate, 0.2, , "RELOAD");
 
 	if (SightingState != SS_None && Type != 1)
 		TemporaryScopeDown(0.5);

--- a/BWBP_JCF_Pro/Classes/M99_TW.uc
+++ b/BWBP_JCF_Pro/Classes/M99_TW.uc
@@ -213,7 +213,7 @@ simulated function Notify_CockAfterReload()
 //	else
 //		PlayAnim('ReloadFinishHandle', ReloadAnimRate, 0.2);
 }
-
+/* 
 simulated function PlayCocking(optional byte Type)
 {
 	if (Type == 2 && HasAnim('Cock'))
@@ -221,7 +221,7 @@ simulated function PlayCocking(optional byte Type)
 	else
 		PlayAnim('Cock', CockAnimRate, 0.2);
 }
-
+*/
 simulated function bool HasAmmo()
 {
 	//First Check the magazine
@@ -250,6 +250,7 @@ defaultproperties
 	NDCrosshairCfg=(Pic1=Texture'BW_Core_WeaponTex.Crosshairs.Misc6',Pic2=Texture'BW_Core_WeaponTex.Crosshairs.Misc5',USize1=256,VSize1=256,USize2=256,VSize2=256,Color1=(B=130,G=135,R=137,A=62),Color2=(B=0,G=172,R=0,A=80),StartSize1=127,StartSize2=96)
 	NDCrosshairInfo=(SpreadRatios=(X1=0.500000,Y1=0.500000,X2=0.500000,Y2=0.750000),SizeFactors=(X1=1.000000,Y1=1.000000,X2=1.000000,Y2=1.000000),MaxScale=4.000000,CurrentScale=0.000000)
 	SelectAnim="Deploy"
+	CockAnimPostReload="Cock"
     BringUpTime=1.000000
 	bCanThrow=False
 	bNoInstagibReplace=True

--- a/BWBP_OP_Pro/Classes/AkeronWarhead.uc
+++ b/BWBP_OP_Pro/Classes/AkeronWarhead.uc
@@ -264,7 +264,7 @@ function ServerBlowUp()
 
 function BlowUp(vector HitLocation)
 {
-	if (bExploded || Owner != None && PlayerController(Controller).AcknowledgedPawn != self || Role != ROLE_Authority)
+	if (bExploded || Owner != None && PlayerController(Controller) != None && PlayerController(Controller).AcknowledgedPawn != self || Role != ROLE_Authority)
 		return;
 
 	ShakeView();

--- a/BWBP_OP_Pro/Classes/CX61AssaultRifle.uc
+++ b/BWBP_OP_Pro/Classes/CX61AssaultRifle.uc
@@ -270,7 +270,7 @@ defaultproperties
 	SpecialInfo(0)=(Info="240.0;25.0;0.8;90.0;0.0;1.0;0.0")
 	BringUpSound=(Sound=Sound'BW_Core_WeaponSound.XK2.XK2-Pullout',Volume=0.210000) 
 	PutDownSound=(Sound=Sound'BW_Core_WeaponSound.XK2.XK2-Putaway',Volume=0.208000)
-	CockAnimPostReload="ReloadEndCock"
+	//CockAnimPostReload="ReloadEndCock"
 	CockSound=(Sound=Sound'BWBP_OP_Sounds.CX61.CX61-Cock')
 	ClipOutSound=(Sound=Sound'BWBP_OP_Sounds.CX61.CX61-MagOut')
 	ClipInSound=(Sound=Sound'BWBP_OP_Sounds.CX61.CX61-MagIn')

--- a/BWBP_OP_Pro/Classes/FM13Shotgun.uc
+++ b/BWBP_OP_Pro/Classes/FM13Shotgun.uc
@@ -228,14 +228,6 @@ function float SuggestDefenseStyle()
 
 // End AI Stuff =====
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2 && HasAnim(CockAnimPostReload))
-		SafePlayAnim(CockAnimPostReload, CockAnimRate, 0.2, , "RELOAD");
-	else
-		SafePlayAnim(CockAnim, CockAnimRate, 0.2, , "RELOAD");
-}
-
 // Animation notify for when cocking action starts. Used to time sounds
 simulated function Notify_CockAimed()
 {

--- a/BWBP_OP_Pro/Classes/M575Machinegun.uc
+++ b/BWBP_OP_Pro/Classes/M575Machinegun.uc
@@ -172,14 +172,6 @@ simulated function Notify_CockAfterReload()
 		PlayAnim('ReloadFinishHold', ReloadAnimRate, 0.2);
 }
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2 && HasAnim('ReloadEndCock'))
-		PlayAnim('ReloadEndCock', CockAnimRate, 0.2);
-	else
-		PlayAnim(CockAnim, CockAnimRate, 0.2);
-}
-
 /*simulated function PositionSights ()
 {
 	super.PositionSights();

--- a/BWBP_OP_Pro/Classes/MX32Weapon.uc
+++ b/BWBP_OP_Pro/Classes/MX32Weapon.uc
@@ -596,7 +596,7 @@ defaultproperties
      SpecialInfo(0)=(Info="240.0;25.0;0.9;80.0;0.7;0.7;2.0")
      BringUpSound=(Sound=Sound'BW_Core_WeaponSound.M50.M50Pullout',Volume=0.222000)
      PutDownSound=(Sound=Sound'BW_Core_WeaponSound.M50.M50Putaway',Volume=0.222000)
-     CockAnimPostReload="ReloadEndCock"
+     //CockAnimPostReload="ReloadEndCock"
      CockSound=(Sound=Sound'BWBP_OP_Sounds.MX32.MX32-Cock',Volume=1.350000)
 	 ClipHitSound=(Sound=Sound'BWBP_OP_Sounds.MX32.MX32-MagHit',Volume=1.350000)
 	 ClipOutSound=(Sound=Sound'BWBP_OP_Sounds.MX32.MX32-MagOut',Volume=1.350000)

--- a/BWBP_OP_Pro/Classes/RCS715Shotgun.uc
+++ b/BWBP_OP_Pro/Classes/RCS715Shotgun.uc
@@ -310,7 +310,7 @@ simulated function LoadGrenadeLoop()
 		return;
 	if ((ReloadState == RS_None || ReloadState == RS_StartShovel)&& Ammo[1].AmmoAmount >= 1)
 	{
-		PlayAnim(StartShovelAnim, 1.0, , 0);
+		PlayAnim(StartShovelAnim, ReloadAnimRate, , 0);
 		ReloadState = RS_StartShovel;
 	}
 }

--- a/BWBP_OP_Pro/Classes/Z250Minigun.uc
+++ b/BWBP_OP_Pro/Classes/Z250Minigun.uc
@@ -319,7 +319,7 @@ simulated function LoadGrenade()
 	if (ReloadState == RS_None)
 	{
 		ReloadState = RS_Cocking;
-		PlayAnim(GrenadeLoadAnim, 1.1, , 0);
+		PlayAnim(GrenadeLoadAnim, ReloadAnimRate+0.1, , 0);
 	}		
 }
 

--- a/BWBP_SKC_Pro/Classes/AH104Pistol.uc
+++ b/BWBP_SKC_Pro/Classes/AH104Pistol.uc
@@ -204,14 +204,6 @@ simulated function BringUp(optional Weapon PrevWeapon)
 	}
 }
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2)
-		PlayAnim('ReloadEndCock', CockAnimRate, 0.2);
-	else
-		PlayAnim(CockAnim, CockAnimRate, 0.2);
-}
-
 simulated function PlayIdle()
 {
 	super.PlayIdle();

--- a/BWBP_SKC_Pro/Classes/AH250Pistol.uc
+++ b/BWBP_SKC_Pro/Classes/AH250Pistol.uc
@@ -291,14 +291,6 @@ simulated event AnimEnd (int Channel)
 	Super.AnimEnd(Channel);
 }
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2)
-		PlayAnim('ReloadEndCock', CockAnimRate, 0.2);
-	else
-		PlayAnim(CockAnim, CockAnimRate, 0.2);
-}
-
 // Secondary fire doesn't count for this weapon
 simulated function bool HasAmmo()
 {

--- a/BWBP_SKC_Pro/Classes/AK490BattleRifle.uc
+++ b/BWBP_SKC_Pro/Classes/AK490BattleRifle.uc
@@ -275,14 +275,6 @@ function AttachToPawn(Pawn P)
 		AK490Attachment(ThirdPersonActor).bLoaded = True;
 }
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2)
-		PlayAnim('ReloadEndCock', CockAnimRate, 0.2);
-	else
-		PlayAnim(CockAnim, CockAnimRate, 0.2);
-}
-
 // Animation notify for when the clip is stuck in
 simulated function Notify_ClipUp()
 {
@@ -384,7 +376,7 @@ defaultproperties
 	MeleeFireClass=Class'BWBP_SKC_Pro.AK490MeleeFire'
 	BringUpSound=(Sound=Sound'BWBP_SKC_Sounds.AK47.AK47-Draw',Volume=0.230000)
 	PutDownSound=(Sound=Sound'BWBP_SKC_Sounds.AK47.AK47-Putaway',Volume=0.240000)
-	CockAnimPostReload="ReloadEndCock"
+	//CockAnimPostReload="ReloadEndCock"
 	//CockingBringUpTime=1.300000
 	CockSound=(Sound=Sound'BWBP_SKC_Sounds.AK47.AK47-Cock',Volume=3.500000)
 	ClipHitSound=(Sound=Sound'BWBP_SKC_Sounds.AK47.AK47-ClipHit',Volume=3.500000)

--- a/BWBP_SKC_Pro/Classes/AK91ChargeRifle.uc
+++ b/BWBP_SKC_Pro/Classes/AK91ChargeRifle.uc
@@ -300,16 +300,6 @@ simulated function Destroyed()
 	super.Destroyed();
 }
 
-
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2)
-		PlayAnim('ReloadEndCock', CockAnimRate, 0.2);
-	else
-		PlayAnim(CockAnim, CockAnimRate, 0.2);
-}
-
-
 simulated function PlayReload()
 {
     if (MagAmmo < 1)
@@ -427,7 +417,7 @@ defaultproperties
      BringUpSound=(Sound=Sound'BW_Core_WeaponSound.M50.M50Pullout',Volume=0.225000)
      PutDownSound=(Sound=Sound'BW_Core_WeaponSound.M50.M50Putaway',Volume=0.225000)
      MagAmmo=30
-     CockAnimPostReload="ReloadEndCock"
+     //CockAnimPostReload="ReloadEndCock"
      CockSound=(Sound=Sound'BWBP_SKC_Sounds.AK47.AK47-Cock',Volume=1.500000)
      ClipHitSound=(Sound=Sound'BWBP_SKC_Sounds.AK47.AK47-ClipHit',Volume=1.500000)
      ClipOutSound=(Sound=Sound'BWBP_SKC_Sounds.AK47.AK47-ClipOut',Volume=1.500000)

--- a/BWBP_SKC_Pro/Classes/AR23HeavyRifle.uc
+++ b/BWBP_SKC_Pro/Classes/AR23HeavyRifle.uc
@@ -98,7 +98,7 @@ simulated function LoadGrenade()
 		return;
 	}
 	if (ReloadState == RS_None)
-		PlayAnim(GrenadeLoadAnim, 1.1, , 0);
+		PlayAnim(GrenadeLoadAnim, ReloadAnimRate+0.1, , 0);
 }
 
 function ServerStartReload (optional byte i)

--- a/BWBP_SKC_Pro/Classes/AS50_TW.uc
+++ b/BWBP_SKC_Pro/Classes/AS50_TW.uc
@@ -209,14 +209,6 @@ simulated function Notify_CockAfterReload()
 //		PlayAnim('ReloadFinishHandle', ReloadAnimRate, 0.2);
 }
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2 && HasAnim('Cock'))
-		PlayAnim('Cock', CockAnimRate, 0.2);
-	else
-		PlayAnim('Cock', CockAnimRate, 0.2);
-}
-
 simulated function bool HasAmmo()
 {
 	//First Check the magazine
@@ -250,6 +242,7 @@ defaultproperties
 	Priority=1
 	PlayerViewOffset=(X=-80.000000)
 	ItemName="FG50 Turret"
+	CockAnimPostReload="Cock"
 	Mesh=SkeletalMesh'BWBP_SKC_Anim.FSSG-50Turret_FPm'
 	DrawScale=0.50000
 	CollisionHeight=24.000000

--- a/BWBP_SKC_Pro/Classes/BulldogAssaultCannon.uc
+++ b/BWBP_SKC_Pro/Classes/BulldogAssaultCannon.uc
@@ -383,7 +383,7 @@ simulated function LoadGrenadeLoop()
 		return;
 	if ((ReloadState == RS_None || ReloadState == RS_StartShovel)&& Ammo[1].AmmoAmount >= 1)
 	{
-		PlayAnim(StartShovelAnim, 1.0, , 0);
+		PlayAnim(StartShovelAnim, StartShovelAnimRate, , 0);
 		ReloadState = RS_StartShovel;
 	}
 }

--- a/BWBP_SKC_Pro/Classes/BulldogAssaultCannon.uc
+++ b/BWBP_SKC_Pro/Classes/BulldogAssaultCannon.uc
@@ -468,9 +468,17 @@ simulated function CommonStartReload (optional byte i)
 
 simulated function PlayCocking(optional byte Type)
 {
+	local float AdjustedCockAnimRate;
+
+    // Adjust cock animation rate only during reloading
+    if (ReloadState != RS_None && ReloadState != RS_Cocking)
+        AdjustedCockAnimRate = CockAnimRate * class'BallisticReplicationInfo'.default.ReloadScale;
+    else
+        AdjustedCockAnimRate = CockAnimRate; // Use default rate for firing
+
 	if (!bAltNeedCock)
 		SafePlayAnim(CockAnim, 1.75, 0.2, , "RELOAD");
-	else SafePlayAnim(CockAnim, CockAnimRate, 0.2, , "RELOAD");
+	else SafePlayAnim(CockAnim, AdjustedCockAnimRate, 0.2, , "RELOAD");
 
 	if (SightingState != SS_None)
 		TemporaryScopeDown(default.SightingTime);

--- a/BWBP_SKC_Pro/Classes/CYLOUAW.uc
+++ b/BWBP_SKC_Pro/Classes/CYLOUAW.uc
@@ -257,12 +257,20 @@ simulated function FirePressed(float F)
 //===========================================================================
 simulated function PlayCocking(optional byte Type)
 {
+	local float AdjustedCockAnimRate;
+
+    // Adjust cock animation rate only during reloading
+    if (ReloadState != RS_None && ReloadState != RS_Cocking)
+        AdjustedCockAnimRate = CockAnimRate * class'BallisticReplicationInfo'.default.ReloadScale;
+    else
+        AdjustedCockAnimRate = CockAnimRate; // Use default rate for firing
+
 	if (Type == 2 && HasAnim(CockAnimPostReload))
-		SafePlayAnim(CockAnimPostReload, CockAnimRate, 0.2, , "RELOAD");
+		SafePlayAnim(CockAnimPostReload, AdjustedCockAnimRate, 0.2, , "RELOAD");
 	else if (Type == 5)
-		SafePlayAnim(CockSGAnim, CockAnimRate, 0.2, , "RELOAD");
+		SafePlayAnim(CockSGAnim, AdjustedCockAnimRate, 0.2, , "RELOAD");
 	else
-		SafePlayAnim(CockAnim, CockAnimRate, 0.2, , "RELOAD");
+		SafePlayAnim(CockAnim, AdjustedCockAnimRate, 0.2, , "RELOAD");
 
 	if (SightingState != SS_None)
 		TemporaryScopeDown(default.SightingTime);

--- a/BWBP_SKC_Pro/Classes/FG50MG_TW.uc
+++ b/BWBP_SKC_Pro/Classes/FG50MG_TW.uc
@@ -214,14 +214,6 @@ simulated function Notify_CockAfterReload()
 //		PlayAnim('ReloadFinishHandle', ReloadAnimRate, 0.2);
 }
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2 && HasAnim('Cock'))
-		PlayAnim('Cock', CockAnimRate, 0.2);
-	else
-		PlayAnim('Cock', CockAnimRate, 0.2);
-}
-
 simulated function bool HasAmmo()
 {
 	//First Check the magazine
@@ -257,6 +249,7 @@ defaultproperties
 	Priority=1
 	PlayerViewOffset=(X=-80.000000)
 	ItemName="FG50 Turret"
+	CockAnimPostReload="Cock"
 	Mesh=SkeletalMesh'BWBP_SKC_Anim.FG50Turret_FPm'
 	DrawScale=0.50000
 	CollisionHeight=24.000000

--- a/BWBP_SKC_Pro/Classes/FG50MachineGun.uc
+++ b/BWBP_SKC_Pro/Classes/FG50MachineGun.uc
@@ -660,7 +660,7 @@ defaultproperties
     PutDownSound=(Sound=Sound'BW_Core_WeaponSound.M50.M50Putaway',Volume=0.222000)
 	MagAmmo=40
 	MeleeFireClass=Class'BWBP_SKC_Pro.FG50MeleeFire'
-	CockAnimPostReload="ReloadEndCock"
+	//CockAnimPostReload="ReloadEndCock"
 	CockSound=(Sound=Sound'BWBP_SKC_Sounds.AS50.FG50-Cock',Volume=2.500000,Radius=32.000000)
 	ClipOutSound=(Sound=Sound'BWBP_SKC_Sounds.AS50.FG50-DrumOut',Volume=1.500000,Radius=32.000000)
 	ClipInSound=(Sound=Sound'BWBP_SKC_Sounds.AS50.FG50-DrumIn',Volume=1.500000,Radius=32.000000)

--- a/BWBP_SKC_Pro/Classes/FMPMachinePistol.uc
+++ b/BWBP_SKC_Pro/Classes/FMPMachinePistol.uc
@@ -364,7 +364,7 @@ defaultproperties
 	SpecialInfo(0)=(Info="240.0;15.0;0.9;80.0;0.7;0.7;0.4")
 	BringUpSound=(Sound=Sound'BWBP_SKC_Sounds.MP40.MP40-Pullout',Volume=0.215000)
 	PutDownSound=(Sound=Sound'BWBP_SKC_Sounds.MP40.MP40-Putaway',Volume=0.217000)
-	CockAnimPostReload="ReloadEndCock"
+	//CockAnimPostReload="ReloadEndCock"
 	CockSound=(Sound=Sound'BWBP_SKC_Sounds.MP40.MP40-Cock',Volume=1.400000)
 	ClipHitSound=(Sound=Sound'BWBP_SKC_Sounds.MP40.MP40-MagHit',Volume=1.400000)
 	ClipOutSound=(Sound=Sound'BWBP_SKC_Sounds.MP40.MP40-MagOut',Volume=1.400000)

--- a/BWBP_SKC_Pro/Classes/G51Carbine.uc
+++ b/BWBP_SKC_Pro/Classes/G51Carbine.uc
@@ -590,7 +590,7 @@ simulated function LoadGrenade()
 	if (ReloadState == RS_None)
 	{
 		ReloadState = RS_GearSwitch;
-		PlayAnim(GrenadeLoadAnim, 1.1, , 0);
+		PlayAnim(GrenadeLoadAnim, ReloadAnimRate+0.1, , 0);
 	}
 }
 

--- a/BWBP_SKC_Pro/Classes/GRSXXPistol.uc
+++ b/BWBP_SKC_Pro/Classes/GRSXXPistol.uc
@@ -345,14 +345,6 @@ simulated function OnScopeViewChanged()
 		SightOffset.Y = default.SightOffset.Y * -1;
 }
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2)
-		PlayAnim('ReloadEndCock', CockAnimRate, 0.2);
-	else
-		PlayAnim(CockAnim, CockAnimRate, 0.2);
-}
-
 simulated function BringUp(optional Weapon PrevWeapon)
 {
 	Super.BringUp(PrevWeapon);

--- a/BWBP_SKC_Pro/Classes/LS14Carbine.uc
+++ b/BWBP_SKC_Pro/Classes/LS14Carbine.uc
@@ -758,7 +758,7 @@ simulated function LoadGrenade()
 
 	if (ReloadState == RS_None)
 	{
-		PlayAnim(HatchOpenAnim, HatchOpenAnimRate, , 0);
+		PlayAnim(HatchOpenAnim, HatchOpenAnimRate * class'BallisticReplicationInfo'.default.ReloadScale, , 0);
 		ReloadState = RS_PreClipOut;
 	}
 }
@@ -770,7 +770,7 @@ simulated function LoadGrenadeLoop()
 		return;
 	if (ReloadState == RS_None)
 	{
-		PlayAnim(HatchOpenAnim, HatchOpenAnimRate, , 0);
+		PlayAnim(HatchOpenAnim, HatchOpenAnimRate * class'BallisticReplicationInfo'.default.ReloadScale, , 0);
 		ReloadState = RS_StartShovel;
 	}
 }

--- a/BWBP_SKC_Pro/Classes/LonghornLauncher.uc
+++ b/BWBP_SKC_Pro/Classes/LonghornLauncher.uc
@@ -74,10 +74,18 @@ simulated function PlayReload()
 
 simulated function PlayCocking(optional byte Type)
 {
+	local float AdjustedCockAnimRate;
+
+    // Adjust cock animation rate only during reloading
+    if (ReloadState != RS_None && ReloadState != RS_Cocking)
+        AdjustedCockAnimRate = CockAnimRate * class'BallisticReplicationInfo'.default.ReloadScale;
+    else
+        AdjustedCockAnimRate = CockAnimRate; // Use default rate for firing
+
 	if (Type == 2 && HasAnim(CockAnimPostReload))
-		SafePlayAnim(CockAnimPostReload, CockAnimRate, 0.2, , "RELOAD");
+		SafePlayAnim(CockAnimPostReload, AdjustedCockAnimRate, 0.2, , "RELOAD");
 	else
-		SafePlayAnim(CockAnim, CockAnimRate, 0.2, , "RELOAD");
+		SafePlayAnim(CockAnim, AdjustedCockAnimRate, 0.2, , "RELOAD");
 
 	if (SightingState != SS_None && SightingState != SS_Active)
 		TemporaryScopeDown(0.5);

--- a/BWBP_SKC_Pro/Classes/M2020GaussDMR.uc
+++ b/BWBP_SKC_Pro/Classes/M2020GaussDMR.uc
@@ -552,7 +552,7 @@ defaultproperties
 	SpecialInfo(0)=(Info="240.0;25.0;1.0;80.0;2.0;0.1;0.1")
 	BringUpSound=(Sound=Sound'WeaponSounds.LightningGun.SwitchToLightningGun',Volume=0.182000)
 	PutDownSound=(Sound=Sound'BW_Core_WeaponSound.M50.M50Putaway',Volume=0.187000)
-	CockAnimPostReload="ReloadEndCock"
+	//CockAnimPostReload="ReloadEndCock"
 	CockSound=(Sound=Sound'BWBP_SKC_Sounds.M2020.M2020-Cock',Volume=1.400000)
 	CockSelectSound=(Sound=Sound'BWBP_SKC_Sounds.M2020.M2020-CockOld',Volume=1.400000)
 	ClipHitSound=(Sound=Sound'BWBP_SKC_Sounds.M2020.M2020-MagHit',Volume=1.400000)

--- a/BWBP_SKC_Pro/Classes/MARSAssaultRifle.uc
+++ b/BWBP_SKC_Pro/Classes/MARSAssaultRifle.uc
@@ -156,7 +156,7 @@ simulated function LoadGrenade()
 	if (ReloadState == RS_None)
 	{
 		ReloadState = RS_GearSwitch;
-		PlayAnim(GrenadeLoadAnim, 1.1, , 0);
+		PlayAnim(GrenadeLoadAnim, ReloadAnimRate+0.1, , 0);
 	}
 }
 
@@ -1097,7 +1097,7 @@ defaultproperties
 	WeaponModes(2)=(ModeName="Auto")
 	CurrentWeaponMode=2
 	
-	CockAnimPostReload="ReloadEndCock"
+	//CockAnimPostReload="ReloadEndCock"
 	CockSound=(Sound=Sound'BWBP_SKC_Sounds.MARS.MARS-BoltPull',Volume=1.100000,Radius=24.000000)
 	ClipHitSound=(Sound=Sound'BWBP_SKC_Sounds.MARS.MARS-MagFiddle',Volume=1.400000,Radius=24.000000)
 	ClipOutSound=(Sound=Sound'BWBP_SKC_Sounds.MARS.MARS-MagOut',Volume=1.400000,Radius=24.000000)

--- a/BWBP_SKC_Pro/Classes/MG36MG_TW.uc
+++ b/BWBP_SKC_Pro/Classes/MG36MG_TW.uc
@@ -209,14 +209,6 @@ simulated function Notify_CockAfterReload()
 //		PlayAnim('ReloadFinishHandle', ReloadAnimRate, 0.2);
 }
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2 && HasAnim('Cock'))
-		PlayAnim('Cock', CockAnimRate, 0.2);
-	else
-		PlayAnim('Cock', CockAnimRate, 0.2);
-}
-
 simulated function bool HasAmmo()
 {
 	//First Check the magazine
@@ -242,6 +234,7 @@ defaultproperties
 	ParamsClasses(2)=Class'MG36TW_WeaponParamsRealistic'
     ParamsClasses(3)=Class'MG36TW_WeaponParamsTactical'
 	SelectAnim="Deploy"
+	CockAnimPostReload="Cock"
 	//IdleAnim="PoseLib"
     BringUpTime=1.600000
 	bCanThrow=False

--- a/BWBP_SKC_Pro/Classes/MK781Shotgun.uc
+++ b/BWBP_SKC_Pro/Classes/MK781Shotgun.uc
@@ -413,7 +413,7 @@ simulated function LoadGrenadeLoop()
 		return;
 	if ((ReloadState == RS_None || ReloadState == RS_StartShovel)&& Ammo[1].AmmoAmount >= 1)
 	{
-		PlayAnim(ReloadAltAnim, 1.0, , 0);
+		PlayAnim(ReloadAltAnim, ReloadAnimRate, , 0);
 		ReloadState = RS_StartShovel;
 	}
 }

--- a/BWBP_SKC_Pro/Classes/MRDRMachinePistol.uc
+++ b/BWBP_SKC_Pro/Classes/MRDRMachinePistol.uc
@@ -181,14 +181,6 @@ simulated event AnimEnd (int Channel)
 	Super.AnimEnd(Channel);
 }
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2)
-		PlayAnim('ReloadEndCock', CockAnimRate, 0.2);
-	else
-		PlayAnim(CockAnim, CockAnimRate, 0.2);
-}
-
 // =============================================
 
 defaultproperties

--- a/BWBP_SKC_Pro/Classes/PS9mPistol.uc
+++ b/BWBP_SKC_Pro/Classes/PS9mPistol.uc
@@ -151,7 +151,7 @@ simulated function LoadGrenade()
 	if (Ammo[1].AmmoAmount < 1 || bLoaded)
 		return;
 	if (ReloadState == RS_None)
-		PlayAnim(GrenadeLoadAnim, 1.1, , 0);
+		PlayAnim(GrenadeLoadAnim, ReloadAnimRate+0.1, , 0);
 	if (Othergun != None)
 	{
 		if (Othergun.Clientstate != WS_ReadyToFire)
@@ -327,16 +327,6 @@ function float SuggestAttackStyle()	{	return 0.8;	}
 function float SuggestDefenseStyle()	{	return -0.8;	}
 // End AI Stuff =================================
 
-
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2)
-		PlayAnim('ReloadEndCock', CockAnimRate, 0.2);
-	else
-		PlayAnim(CockAnim, CockAnimRate, 0.2);
-}
-
-// =============================================
 
 defaultproperties
 {

--- a/BWBP_SKC_Pro/Classes/PugAssaultCannon.uc
+++ b/BWBP_SKC_Pro/Classes/PugAssaultCannon.uc
@@ -414,9 +414,17 @@ simulated function CommonStartReload (optional byte i)
 
 simulated function PlayCocking(optional byte Type)
 {
+	local float AdjustedCockAnimRate;
+
+    // Adjust cock animation rate only during reloading
+    if (ReloadState != RS_None && ReloadState != RS_Cocking)
+        AdjustedCockAnimRate = CockAnimRate * class'BallisticReplicationInfo'.default.ReloadScale;
+    else
+        AdjustedCockAnimRate = CockAnimRate; // Use default rate for firing
+
 	if (!bAltNeedCock)
 		SafePlayAnim(CockAnim, 1.75, 0.2, , "RELOAD");
-	else SafePlayAnim(CockAnim, CockAnimRate, 0.2, , "RELOAD");
+	else SafePlayAnim(CockAnim, AdjustedCockAnimRate, 0.2, , "RELOAD");
 
 	if (SightingState != SS_None)
 		TemporaryScopeDown(default.SightingTime);

--- a/BWBP_SKC_Pro/Classes/PugAssaultCannon.uc
+++ b/BWBP_SKC_Pro/Classes/PugAssaultCannon.uc
@@ -329,7 +329,7 @@ simulated function LoadGrenadeLoop()
 		return;
 	if ((ReloadState == RS_None || ReloadState == RS_StartShovel)&& Ammo[1].AmmoAmount >= 1)
 	{
-		PlayAnim(StartShovelAnim, 1.0, , 0);
+		PlayAnim(StartShovelAnim, StartShovelAnimRate, , 0);
 		ReloadState = RS_StartShovel;
 	}
 }

--- a/BWBP_SKC_Pro/Classes/RS04Pistol.uc
+++ b/BWBP_SKC_Pro/Classes/RS04Pistol.uc
@@ -346,14 +346,6 @@ simulated function Destroyed ()
 	super.Destroyed();
 }
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2)
-		PlayAnim('ReloadEndCock', CockAnimRate, 0.2);
-	else
-		PlayAnim(CockAnim, CockAnimRate, 0.2);
-}
-
 simulated function BringUp(optional Weapon PrevWeapon)
 {
 

--- a/BWBP_SKC_Pro/Classes/SX45Pistol.uc
+++ b/BWBP_SKC_Pro/Classes/SX45Pistol.uc
@@ -416,14 +416,6 @@ simulated function Destroyed ()
 	super.Destroyed();
 }
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2)
-		PlayAnim('ReloadEndCock', CockAnimRate, 0.2);
-	else
-		PlayAnim(CockAnim, CockAnimRate, 0.2);
-}
-
 simulated event AnimEnd (int Channel)
 {
     local name Anim;

--- a/BWBP_SKC_Pro/Classes/VSKTranqRifle.uc
+++ b/BWBP_SKC_Pro/Classes/VSKTranqRifle.uc
@@ -61,7 +61,7 @@ defaultproperties
      SpecialInfo(0)=(Info="320.0;25.0;1.0;110.0;2.0;0.1;0.1")
      BringUpSound=(Sound=Sound'BWBP_SKC_Sounds.VSK.VSK-Draw',Volume=0.200000)
      PutDownSound=(Sound=Sound'BWBP_SKC_Sounds.VSK.VSK-Holster',Volume=0.170000)
-     CockAnimPostReload="ReloadEndCock"
+     //CockAnimPostReload="ReloadEndCock"
      CockSound=(Sound=Sound'BWBP_SKC_Sounds.VSK.VSK-Cock',Volume=1.000000)
      ClipOutSound=(Sound=Sound'BWBP_SKC_Sounds.VSK.VSK-ClipOut',Volume=1.500000)
      ClipInSound=(Sound=Sound'BWBP_SKC_Sounds.VSK.VSK-ClipIn',Volume=1.500000)

--- a/BWBP_SKC_Pro/Classes/X82Rifle_TW.uc
+++ b/BWBP_SKC_Pro/Classes/X82Rifle_TW.uc
@@ -193,14 +193,6 @@ simulated function Notify_CockAfterReload()
 //		PlayAnim('ReloadFinishHandle', ReloadAnimRate, 0.2);
 }
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2 && HasAnim('Cock'))
-		PlayAnim('Cock', CockAnimRate, 0.2);
-	else
-		PlayAnim('Cock', CockAnimRate, 0.2);
-}
-
 defaultproperties
 {
 	MountFireSound=Sound'BWBP_SKC_Sounds.X82.X82-Fire4'
@@ -216,6 +208,7 @@ defaultproperties
 	FireModeClass(0)=Class'BWBP_SKC_Pro.X82TW_PrimaryFire'
 	NDCrosshairCfg=(Pic1=Texture'BW_Core_WeaponTex.Crosshairs.Cross4',Pic2=Texture'BW_Core_WeaponTex.Crosshairs.Dot1',USize1=256,VSize1=256,Color1=(B=255,G=255,A=60),Color2=(G=0),StartSize1=22,StartSize2=8)
 	SelectAnim="Deploy"
+	CockAnimPostReload="Cock"
 	BringUpTime=1.000000
 	bCanThrow=False
 	bNoInstagibReplace=True

--- a/BWBP_SWC_Pro/Classes/BRINKAssaultRifle.uc
+++ b/BWBP_SWC_Pro/Classes/BRINKAssaultRifle.uc
@@ -513,7 +513,7 @@ simulated function LoadGrenade()
 	if (ReloadState == RS_None)
 	{
 		ReloadState = RS_GearSwitch;
-		PlayAnim(GrenadeLoadAnim, 1.1, , 0);
+		PlayAnim(GrenadeLoadAnim, ReloadAnimRate+0.1, , 0);
 	}
 }
 
@@ -754,7 +754,7 @@ defaultproperties
 	SpecialInfo(0)=(Info="320.0;25.0;1.0;110.0;0.8;0.5;0.0")
     BringUpSound=(Sound=Sound'BW_Core_WeaponSound.M50.M50Pullout',Volume=0.222000)
     PutDownSound=(Sound=Sound'BW_Core_WeaponSound.M50.M50Putaway',Volume=0.222000)
-	CockAnimPostReload="ReloadEndCock"
+	//CockAnimPostReload="ReloadEndCock"
 	CockAnimRate=0.95000
 	CockSound=(Sound=Sound'BWBP_SWC_Sounds.BR1NK.BR1NK-Cock',Volume=1.100000,Radius=32.000000)
 	ReloadAnimRate=0.950000

--- a/BWBP_SWC_Pro/Classes/MDKSubMachinegun.uc
+++ b/BWBP_SWC_Pro/Classes/MDKSubMachinegun.uc
@@ -132,14 +132,6 @@ simulated function WeaponTick(float DT)
 	}
 }
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2)
-		PlayAnim('ReloadEndCock', CockAnimRate, 0.2);
-	else
-		PlayAnim(CockAnim, CockAnimRate, 0.2);
-}
-
 function ServerSwitchSilencer(bool bNewValue)
 {
 	if (bNewValue == bSilenced)

--- a/BallisticProV55/Classes/AM67Pistol.uc
+++ b/BallisticProV55/Classes/AM67Pistol.uc
@@ -108,14 +108,6 @@ simulated function BringUp(optional Weapon PrevWeapon)
 		AM67Attachment(ThirdPersonActor).bLaserOn = bLaserOn;
 }
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2)
-		PlayAnim('ReloadEndCock', CockAnimRate, 0.2);
-	else
-		PlayAnim(CockAnim, CockAnimRate, 0.2);
-}
-
 simulated function float ChargeBar()
 {
 	if (bHasCombatLaser)

--- a/BallisticProV55/Classes/BallisticInteraction.uc
+++ b/BallisticProV55/Classes/BallisticInteraction.uc
@@ -35,7 +35,7 @@ function DrawSplash( canvas C )
 {
 	local float XL, YL;
 
-	if (PC.Level.TimeSeconds - SplashStartTime > 7.9)
+	if (PC.Level.TimeSeconds - SplashStartTime > 6.4)
 	{
 		bShowSplash=false;
 
@@ -55,7 +55,7 @@ function DrawSplash( canvas C )
 	if (PC.Level.TimeSeconds - SplashStartTime < 5)
 		C.SetDrawColor(255,255,255,255);
 	else
-		C.SetDrawColor(255,255,255, FClamp(255 * (1-((PC.Level.TimeSeconds-SplashStartTime-5)/3.0)), 0, 255));
+		C.SetDrawColor(255,255,255, FClamp(255 * (1-((PC.Level.TimeSeconds-SplashStartTime-5)/1.5)), 0, 255));
 
 	C.DrawTile(SplashPic, 600*ScaleFactor, 600*ScaleFactor, 0,0,512,512);
 

--- a/BallisticProV55/Classes/BallisticPawn.uc
+++ b/BallisticProV55/Classes/BallisticPawn.uc
@@ -167,6 +167,33 @@ var 	float 				StrafeScale, BackpedalScale;
 var 	float 				MyFriction, OldMovementSpeed;
 var     bool                bCanDodge;
 
+// Sliding Variables
+var() bool bAllowCrouchSliding; // Whether crouch sliding is allowed
+var() float SlideFriction;		 // Friction applied during sliding, affects how quickly the player slows down
+var() float SlideCooldownTime;	// Time before the player can slide again after a slide ends
+var() float SlidePower;			 // Initial burst power when starting a slide, affects how fast the player accelerates at the start of the slide
+var bool bIsSliding;			 // Is the player currently sliding?
+var float LastSlideEndTime;		// Time when the last slide ended
+var float LastLandTime;			// Time when the player last landed
+var vector SlideVelocity;		// Velocity during the slide
+var float SlideStartSpeed;		 // Speed required to start sliding
+var float SlideStopSpeed;		 // Speed below which sliding stops
+var float MaxSlideSpeed;		// Maximum speed during sliding, our groundspeed becomes this in order to move faster
+var float SlideEyeHeight;		 // Eye height during sliding, used to adjust camera position
+
+// Slope/Physics Calculations
+var float SlopeAngleRad;		 // Angle of the slope in radians
+var float SlopeAngleDeg;		 // Angle of the slope in degrees
+var vector DownSlopeVect;		 // Direction vector pointing down the slope
+var vector LastFallingVelocity;	 // Velocity of the player when they last fell, used to determine sliding behavior
+var float GravityAlongSlope;	 // Gravity component acting along the slope, used to calculate acceleration during sliding
+
+// Sliding Animations
+var 	name 		SlideAnims[4]; 
+var 	name 		SlideStartAnims[4]; 
+var 	name 		SlideEndAnims[4]; 
+
+
 //Wall running stuff
 //var bool bLockedToSurface; // Tracks if the player is locked to a surface
 //var vector LockedSurfaceNormal; // Stores the normal of the locked surface
@@ -179,7 +206,8 @@ var() float JumpCrouchTime;
 replication
 {
 	reliable if (Role == ROLE_Authority)
-		ClientHits, HitCounter, ClientSetCrouchAbility;
+		ClientHits, HitCounter, ClientSetCrouchAbility,
+		bIsSliding, SlideVelocity, Sprinter;
 }
 
 simulated event PostNetBeginPlay()
@@ -271,6 +299,8 @@ simulated function ApplyMovementOverrides()
     {
         bCanDoubleJump = false;
     }
+
+	bAllowCrouchSliding = class'BallisticReplicationInfo'.default.bAllowCrouchSliding;
 
 	WalkingPct = class'BallisticReplicationInfo'.default.PlayerWalkSpeedFactor;
 	CrouchedPct = class'BallisticReplicationInfo'.default.PlayerCrouchSpeedFactor;
@@ -513,7 +543,10 @@ function bool AddInventory( inventory NewItem )
     ret = Super.AddInventory(NewItem);
 
     if(NewItem != none && BCSprintControl(NewItem) != none)
+	{
         sprinter = BCSprintControl(NewItem);
+		log("BallisticPawn: AddInventory: Added BCSprintControl " @ sprinter);
+	}
 
     return ret;
 }
@@ -537,6 +570,8 @@ event Landed(vector HitNormal)
 
     MultiJumpRemaining = MaxMultiJump;
 
+	LastLandTime = Level.TimeSeconds;
+
 	if (Role == ROLE_Authority && Inventory != None)
 		Inventory.OwnerEvent('Landed');
 
@@ -555,7 +590,7 @@ function PawnCheckBob(float DeltaTime, vector Y)
 {
 	local float Speed2D;
 
-    if(bJustLanded || (Sprinter != None && Sprinter.bIsSliding))
+    if(bJustLanded || bIsSliding)
     {
 		BobTime = 0;
 		WalkBob = Vect(0,0,0);
@@ -933,7 +968,7 @@ simulated event SetAnimAction(name NewAction)
 				PlayAnim(MeleeBlockAnim,, 0.2, 1);
 			IdleWeaponAnim = MeleeBlockAnim;
 			FireState = FS_None;
-			Instigator.ClientMessage("Blocking");
+			ClientMessage("Blocking");
 			return;
 		}		
 		else */if (AnimAction == 'Raise' && HasAnim(IdleRifleAnim))
@@ -1647,6 +1682,10 @@ simulated event Tick(float DT)
 	}
 	// Gore tick
 	TickGore(DT);
+
+	// Slope calculation
+	if(bAllowCrouchSliding) 
+		TickSlopeCalculation(DT);
 
 	// Dissolve DeRes corpses
 	if (bDeRes)
@@ -2455,8 +2494,7 @@ event StartCrouch(float HeightAdjust)
 	EyeHeight += HeightAdjust;
 	OldZ -= HeightAdjust;
 	BaseEyeheight = CrouchEyeHeight;
-	if (Role == ROLE_Authority)
-		Inventory.OwnerEvent('Crouched');
+	TryStartSlide();
 }
 
 event EndCrouch(float HeightAdjust)
@@ -3284,59 +3322,208 @@ simulated event ModifyVelocity(float DeltaTime, vector OldVelocity)
 	local Vector X, Y, Z, dir;
 	local float FSpeed, Control, NewSpeed, Drop, XSpeed, YSpeed, CosAngle, MaxStrafeSpeed, MaxBackSpeed;
 
-	if (Physics != PHYS_Walking)
+	if (Physics == PHYS_Falling)
+        LastFallingVelocity = Velocity;
+
+	if (Physics == PHYS_Walking)
+	{
+		// constrains strafe move
+		if (StrafeScale < 1f || BackpedalScale < 1f)
+		{
+			GetAxes(GetViewRotation(),X,Y,Z);
+			MaxStrafeSpeed = GroundSpeed * StrafeScale;
+			MaxBackSpeed = GroundSpeed * BackpedalScale;
+
+			// backwards speed limit
+			XSpeed = Abs(X dot Velocity);
+			
+			if (XSpeed > MaxBackSpeed && (x dot Velocity) < 0)
+			{
+				//limiting backspeed
+				dir = Normal(Velocity);
+				CosAngle = Abs(X dot dir);
+				Velocity = dir * (MaxBackSpeed / CosAngle);
+			}
+			
+			// strafe speed limit
+			YSpeed = Abs(Y dot velocity);
+
+			if (YSpeed > MaxStrafeSpeed)
+			{
+				//limiting strafespeed
+				dir = Normal(Velocity);
+				CosAngle = Abs(Y dot dir);
+				Velocity = dir * (MaxStrafeSpeed / CosAngle);
+			}
+		}
+
+		//ClientMessage("Speed:"$string(VSize(Velocity) / GroundSpeed));
+			
+		// Applies decelerative friction
+		if (class'BallisticReplicationInfo'.default.bPlayerDeceleration)
+		{
+			FSpeed = VSize(Velocity);
+				
+			if (VSize(Acceleration) < 1.00 && FSpeed > 1.00 && !bIsSliding) //We don't want this when sliding
+			{
+				Control = FMin(100, FSpeed);
+					
+				Drop = Control * DeltaTime * MyFriction;
+				NewSpeed = FSpeed + drop;
+				NewSpeed = FClamp(NewSpeed, 0, OldMovementSpeed*0.97) / FSpeed;
+				Velocity *= NewSpeed;
+			}
+		}
+
+		SlideEyeHeight = BaseEyeHeight;
+
+		if (bIsSliding)
+		{
+			HandleSliding(DeltaTime);
+			EyeHeight = SlideEyeHeight * 0.6; // Lower eye height while sliding
+		}
+		else
+		{
+			SlideStartSpeed = class'BallisticReplicationInfo'.default.PlayerGroundSpeed*1.1;
+			SlideStopSpeed = class'BallisticReplicationInfo'.default.PlayerGroundSpeed*0.2;
+			MaxSlideSpeed = class'BallisticReplicationInfo'.default.PlayerGroundSpeed*2.5;
+			if(Level.TimeSeconds > LastLandTime + 0.1)
+				LastFallingVelocity = vect(0,0,0); 
+			if (bIsCrouched)
+			{
+				CrouchedPct = default.CrouchedPct;
+				EyeHeight = Lerp(DeltaTime * 1.5, EyeHeight, SlideEyeHeight, true);
+			}
+		}
+
+		OldMovementSpeed = VSize(Velocity);
+	}
+	// End slide if crouch released, speed too low, or airborne
+	if (Role == ROLE_Authority)
+	{
+		if (bIsSliding && (!bIsCrouched || VSize(SlideVelocity) < SlideStopSpeed || Physics != PHYS_Walking))
+		{
+			EndSlide();
+		}
+	}
+}
+
+simulated function TryStartSlide()
+{
+    if (Role < ROLE_Authority)
+        ServerStartSlide();
+    else
+        StartSlide();
+}
+
+function ServerStartSlide()
+{
+    StartSlide();
+}
+
+function StartSlide()
+{
+    local name Anim;
+
+	if (!bAllowCrouchSliding)
 		return;
 
-	// constrains strafe move
-	if (StrafeScale < 1f || BackpedalScale < 1f)
-	{
-		GetAxes(GetViewRotation(),X,Y,Z);
-		MaxStrafeSpeed = GroundSpeed * StrafeScale;
-		MaxBackSpeed = GroundSpeed * BackpedalScale;
-
-		// backwards speed limit
-		XSpeed = Abs(X dot Velocity);
-		
-		if (XSpeed > MaxBackSpeed && (x dot Velocity) < 0)
-		{
-			//limiting backspeed
-			dir = Normal(Velocity);
-			CosAngle = Abs(X dot dir);
-			Velocity = dir * (MaxBackSpeed / CosAngle);
-		}
-		
-		// strafe speed limit
-		YSpeed = Abs(Y dot velocity);
-
-		if (YSpeed > MaxStrafeSpeed)
-		{
-			//limiting strafespeed
-			dir = Normal(Velocity);
-			CosAngle = Abs(Y dot dir);
-			Velocity = dir * (MaxStrafeSpeed / CosAngle);
-		}
-	}
-
-	//ClientMessage("Speed:"$string(VSize(Velocity) / GroundSpeed));
-		
-	// Applies decelerative friction
-	if (class'BallisticReplicationInfo'.default.bPlayerDeceleration)
-	{
-		FSpeed = VSize(Velocity);
-			
-		if (VSize(Acceleration) < 1.00 && FSpeed > 1.00 && Sprinter != None && !Sprinter.bIsSliding) //We don't want this when sliding
-		{
-			Control = FMin(100, FSpeed);
-				
-			Drop = Control * DeltaTime * MyFriction;
-			NewSpeed = FSpeed + drop;
-			NewSpeed = FClamp(NewSpeed, 0, OldMovementSpeed*0.97) / FSpeed;
-			Velocity *= NewSpeed;
-		}
-	}
-
-	OldMovementSpeed = VSize(Velocity);
+    if (!bIsSliding 
+	&& Controller.bDuck > 0 
+	&& (VSize(LastFallingVelocity) > SlideStartSpeed || VSize(Velocity) > SlideStartSpeed || SlopeAngleDeg < 0.0)
+	&& Physics == PHYS_Walking 
+	&& (Level.TimeSeconds - LastSlideEndTime > SlideCooldownTime))
+    {
+		Sprinter.DelayRecharge();
+		Sprinter.StopSprint();
+		SlideVelocity = Velocity * 0.5 + LastFallingVelocity * 0.5; //Blend current velocity with last falling velocity
+		SlideVelocity += Normal(SlideVelocity) * FMax(SlidePower*0.5,SlidePower * (Sprinter.Stamina / Sprinter.MaxStamina));
+		// Clamp slide velocity to max speed
+        if (VSize(SlideVelocity) > MaxSlideSpeed)
+            SlideVelocity = Normal(SlideVelocity) * MaxSlideSpeed;
+		LastFallingVelocity = vect(0,0,0); 
+        bIsSliding = true;
+        GroundSpeed = MaxSlideSpeed;
+        Anim = SlideStartAnims[Get4WayDirection()];
+        if ( PlayAnim(Anim, 1.0, 0.1) )
+            bWaitForAnim = true;
+        AnimAction = Anim;
+    }
 }
+
+function EndSlide()
+{
+	local name Anim;
+
+	if(!bIsCrouched && VSize(Velocity) < SlideStopSpeed + 50.0) //Play this if not crouched and below certain speed so it looks natural
+	{
+		Anim = SlideEndAnims[Get4WayDirection()];
+		if ( PlayAnim(Anim, 1.0, 0.1) )
+			bWaitForAnim = true;
+		AnimAction = Anim;
+	}
+    bIsSliding = false;
+    SlideVelocity = vect(0,0,0);
+    LastSlideEndTime = Level.TimeSeconds;
+    GroundSpeed = Sprinter.BaseGroundSpeed;
+}
+
+simulated function TickSlopeCalculation(float DT)
+{
+	DownSlopeVect = Normal(vect(0,0,-1) - (Floor dot vect(0,0,-1)) * Floor);
+	SlopeAngleRad = Acos(Floor dot vect(0,0,1));
+	SlopeAngleDeg = SlopeAngleRad * (180.0 / Pi);
+	if (Normal(Velocity) dot DownSlopeVect > 0)
+		SlopeAngleDeg = -SlopeAngleDeg; // Negative when going downhill
+}
+
+simulated function HandleSliding(float DT)
+{
+	local float DynamicFriction;
+	local name Anim;
+
+	CrouchedPct = 1.0; //Little hack so it doesn't mess with crouch speed/ground speed, etc...
+	GravityAlongSlope = -PhysicsVolume.Gravity.Z * Sin(SlopeAngleRad);
+	// Friction increases over time
+	DynamicFriction = SlideFriction;
+	// Reduce friction on steep slopes for more sliding
+	if (SlopeAngleDeg < 0) // Downhill
+		DynamicFriction *= FClamp(1.0 - (Abs(SlopeAngleDeg) / 60.0), 0.2, 1.0);
+	else  // Uphill
+		DynamicFriction *= FClamp(1.0 + (SlopeAngleDeg / 45.0), 1.0, 2.5);
+	//Need to make sure we only apply this when on stairs, DetectStairDirection() might return an angle when on a slope that is not a stair
+	
+	//If we're on stairs, but not on a slope, adjust friction and gravity, hacky but it works!
+	if(SlopeAngleDeg == 0.0 && Floor != Vect(0,0,1)) 
+	{
+		if (PlayerController(Controller).FindStairRotation(DT) < 0) 
+		{
+			DynamicFriction *= 0.5;
+			GravityAlongSlope *= 1.5; 
+		}
+		else
+		{
+			DynamicFriction *= 1.5;
+			GravityAlongSlope *= 0.5; 
+		}
+	}
+	
+	// If going downhill, accelerate; if uphill, decelerate
+	SlideVelocity += DownSlopeVect * GravityAlongSlope * 1.5 * DT;
+
+	// Friction force
+	if (VSize(SlideVelocity) > 0.1)
+		SlideVelocity -= Normal(SlideVelocity) * DynamicFriction * -PhysicsVolume.Gravity.Z * Cos(SlopeAngleRad) * DT;
+
+	// Apply slide velocity to pawn, handle this on the pawn instead
+	Velocity = Velocity * 0.3 + SlideVelocity * 0.7;
+	if (VSize(Velocity) > MaxSlideSpeed)
+		Velocity = Normal(Velocity) * MaxSlideSpeed;
+
+	Anim = SlideAnims[Get4WayDirection()];
+	LoopAnim(Anim, 1.0, 0.2);
+}
+
 
 defaultproperties
 {
@@ -3421,6 +3608,22 @@ defaultproperties
 	 JumpCrouchTime=0.30
      //DodgeSpeedFactor=1.200000
      //DodgeSpeedZ=190.000000
+
+	 SlideFriction=1.100000
+     SlideCooldownTime=0.600000
+	 SlidePower=350.000000
+	 SlideAnims(0)="SlideF"
+	 SlideAnims(1)="SlideF"
+	 SlideAnims(2)="SlideL"
+	 SlideAnims(3)="SlideR"
+	 SlideStartAnims(0)="SlideFStart"
+	 SlideStartAnims(1)="SlideFStart"
+	 SlideStartAnims(2)="SlideLStart"
+	 SlideStartAnims(3)="SlideRStart"
+	 SlideEndAnims(0)="SlideFEnd"
+	 SlideEndAnims(1)="SlideFEnd"
+	 SlideEndAnims(2)="SlideLEnd"
+	 SlideEndAnims(3)="SlideRSEnd
 
      Begin Object Class=KarmaParamsSkel Name=PawnKParams
          KConvulseSpacing=(Max=2.200000)

--- a/BallisticProV55/Classes/BallisticPawn.uc
+++ b/BallisticProV55/Classes/BallisticPawn.uc
@@ -167,6 +167,16 @@ var 	float 				StrafeScale, BackpedalScale;
 var 	float 				MyFriction, OldMovementSpeed;
 var     bool                bCanDodge;
 
+//Wall running stuff
+var bool bLockedToSurface; // Tracks if the player is locked to a surface
+var vector LockedSurfaceNormal; // Stores the normal of the locked surface
+
+// --- Crouch/Jump Parameters ---
+var float  CrouchEndTime;
+var() float JumpCrouchPenalty;   // Jump height multiplier for crouching
+var() float JumpCrouchTime;
+
+
 replication
 {
 	reliable if (Role == ROLE_Authority)
@@ -513,8 +523,10 @@ event HitWall(vector HitNormal, actor Wall)
 {
 	if (Controller != None)
 		Controller.NotifyHitWall(HitNormal, Wall);
+	
 	if (VSize(Velocity) > 900)
 		bPendingNegation=True;
+	
 }
 
 event Landed(vector HitNormal)
@@ -526,10 +538,13 @@ event Landed(vector HitNormal)
 
     MultiJumpRemaining = MaxMultiJump;
 
+	if (Role == ROLE_Authority)
+		Inventory.OwnerEvent('Landed');
+
 	// temporary hardcode
     if ( (Health > 0) && !bHidden && (Level.TimeSeconds - SplashTime > 0.25) )
 		PlayOwnedSound(GetSound(EST_Land), SLOT_Interact, 0.5, true, 30);
-	
+
      //PlayOwnedSound(GetSound(EST_Land), SLOT_Interact, FMin(1, -0.3 * Velocity.Z/JumpZ), true, 1024 + (Velocity.Z * 0.65));
 }
 
@@ -541,7 +556,7 @@ function PawnCheckBob(float DeltaTime, vector Y)
 {
 	local float Speed2D;
 
-    if(bJustLanded )
+    if(bJustLanded || (Sprinter != None && Sprinter.bIsSliding))
     {
 		BobTime = 0;
 		WalkBob = Vect(0,0,0);
@@ -1597,8 +1612,13 @@ simulated function ReceiveHitInfo(NetHitInfo PHI)
 simulated event Tick(float DT)
 {
 	local int Index, i, Diff;
+	local vector TraceStart, TraceEnd, HitLocation, HitNormal;
+    local Actor HitActor;
+	local Vector X,Y,Z;
 
 	super.Tick(DT);
+
+	GetAxes(Rotation, X, Y, Z);
 	
 	if (bPendingNegation)
 	{
@@ -1639,6 +1659,33 @@ simulated event Tick(float DT)
 				NewDeResFinalBlends[i].AlphaRef = Index;
 		}
 	}
+
+	if (bLockedToSurface)
+	{
+		// Perform a trace to check if the player is still near the wall
+		TraceStart = Location + CollisionHeight * vect(0, 0, 1);
+		TraceEnd = Location - LockedSurfaceNormal * CollisionRadius * 2; // Trace towards the locked surface
+		HitActor = Trace(HitLocation, HitNormal, TraceEnd, TraceStart, false, vect(1,1,1));
+		if (HitActor != None && (HitActor.bWorldGeometry || Mover(HitActor) != None) 
+		&& Normal(Velocity) dot X > 0 && LockedSurfaceNormal dot HitNormal > 0.95 && VSize(Velocity) > 50.0)
+		{			
+			// Slow descent
+			Velocity.Z = FMax(Velocity.Z, -100.0); 
+			//AirControl = 0.8; // Higher air control for smoother movement
+			MultiJumpRemaining = MaxMultiJump; // Reset multi-jump count
+		}
+		else
+		{
+			StopWallRun();
+		}
+	}
+}
+
+simulated function StopWallRun()
+{
+	bLockedToSurface = false;
+	LockedSurfaceNormal = vect(0, 0, 0);
+	//AirControl = default.AirControl; // Reset air control
 }
 
 // Return true if the input bone is already dismembered
@@ -2407,7 +2454,9 @@ event StartCrouch(float HeightAdjust)
 {
 	EyeHeight += HeightAdjust;
 	OldZ -= HeightAdjust;
-	BaseEyeHeight = CrouchEyeHeight;
+	BaseEyeheight = CrouchEyeHeight;
+	if (Role == ROLE_Authority)
+		Inventory.OwnerEvent('Crouched');
 }
 
 event EndCrouch(float HeightAdjust)
@@ -2415,7 +2464,16 @@ event EndCrouch(float HeightAdjust)
 	EyeHeight -= HeightAdjust;
 	OldZ += HeightAdjust;
 	BaseEyeHeight = Default.BaseEyeHeight;
+	CrouchEndTime = Level.TimeSeconds;
 }
+
+event Falling()
+{
+    Super.Falling();
+	if (Role == ROLE_Authority)
+		Inventory.OwnerEvent('Falling');
+}
+
 
 // This is a fix for some stupid ass bug that emanates from beyond my reach.
 // It causes BaseEyeHeight to be forced to 38 on the server for non local players (unless the server player is first person spectating that client)
@@ -2439,6 +2497,7 @@ function DoDoubleJump( bool bUpdating )
         SetPhysics(PHYS_Falling);
         if ( !bUpdating )
 			PlayOwnedSound(GetSound(EST_DoubleJump), SLOT_Pain, GruntVolume, , GruntRadius);
+		StopWallRun();
     }
 
 	if (Role == ROLE_Authority)
@@ -2539,6 +2598,10 @@ function bool CanMultiJump()
 
 function bool Dodge(eDoubleClickDir DoubleClickMove)
 {
+    local vector X, Y, Z, TraceStart, TraceEnd, Dir, HitLocation, HitNormal;
+    local Actor HitActor;
+    local rotator TurnRot;
+
 	if (!bCanDodge)
 		return false;
 
@@ -2554,6 +2617,30 @@ function bool Dodge(eDoubleClickDir DoubleClickMove)
         return true;
     }
 
+    TurnRot.Yaw = Rotation.Yaw;
+    GetAxes(TurnRot, X, Y, Z);
+
+    if (Physics == PHYS_Falling)
+    {
+        // Determine direction for wall trace based on input
+        if (DoubleClickMove == DCLICK_Left)
+            Dir = -Y; // Left
+        else if (DoubleClickMove == DCLICK_Right)
+            Dir = Y; // Right
+
+        // Perform wall trace
+        TraceStart = Location - CollisionHeight * vect(0, 0, 1);
+        TraceEnd = TraceStart + Dir * CollisionRadius * 2; // Extend trace outward
+        HitActor = Trace(HitLocation, HitNormal, TraceEnd, TraceStart, false, vect(1, 1, 1));
+        // Check if wall is valid
+        if (HitActor != None && (HitActor.bWorldGeometry || Mover(HitActor) != None))
+        {
+            // Initiate wall running
+            bLockedToSurface = true;
+            LockedSurfaceNormal = HitNormal;
+        }
+    }
+
     return false;
 }
 
@@ -2562,11 +2649,9 @@ function bool DoJump( bool bUpdating )
 	local float OldJumpZ;
 
 	OldJumpZ = JumpZ;
-
+	
 	if (BallisticWeapon(Weapon) != None)
-    {	
         JumpZ = BallisticWeapon(Weapon).GetModifiedJumpZ(self);
-    }
 
     if ( !bUpdating && CanDoubleJump() && (Abs(Velocity.Z) < 100) && IsLocallyControlled() )
     {
@@ -2578,18 +2663,39 @@ function bool DoJump( bool bUpdating )
         JumpZ = OldJumpZ;
         return true;
     }
+	//Allow crouch jumping
+	if ( ((Physics == PHYS_Walking) || (Physics == PHYS_Ladder) || (Physics == PHYS_Spider)) )
+	{
+		if ( Role == ROLE_Authority )
+		{
+			if ( (Level.Game != None) && (Level.Game.GameDifficulty > 2) )
+				MakeNoise(0.1 * Level.Game.GameDifficulty);
+			if ( bCountJumps && (Inventory != None) )
+				Inventory.OwnerEvent('Jumped');
+		}
+		if ( Physics == PHYS_Spider )
+			Velocity = JumpZ * Floor;
+		else if ( Physics == PHYS_Ladder )
+			Velocity.Z = 0;
+		else if ( bIsWalking )
+			Velocity.Z = Default.JumpZ;
+		else
+			Velocity.Z = JumpZ;
+		if ( (Base != None) && !Base.bWorldGeometry )
+			Velocity += Base.Velocity;
 
-    if ( Super(UnrealPawn).DoJump(bUpdating) )
-    {
+        if( bIsCrouched || bWantsToCrouch || Level.TimeSeconds - CrouchEndTime < JumpCrouchTime )
+            Velocity.Z -= JumpZ * JumpCrouchPenalty;
+	
+		SetPhysics(PHYS_Falling);
 		if ( !bUpdating )
-			PlayOwnedSound(GetSound(EST_Jump), SLOT_Pain, GruntVolume, , GruntRadius);
-
-        JumpZ = OldJumpZ;   
+			PlayOwnedSound(GetSound(EST_Jump), SLOT_Pain, GruntVolume,,80);
+		JumpZ = OldJumpZ;
+		StopWallRun();
         return true;
-    }
-
-    // wtb: raii
-    JumpZ = OldJumpZ;
+	}
+	JumpZ = OldJumpZ;
+	//log("2 JumpZ after weapon modification: " @ JumpZ);
     return false;
 }
 
@@ -2634,7 +2740,7 @@ function bool PerformDodge(eDoubleClickDir DoubleClickMove, vector Dir, vector C
             bWaitForAnim = true;
             AnimAction = Anim;
             
-		TakeFallingDamage();
+		//TakeFallingDamage();
         if (Velocity.Z < -DodgeSpeedZ*0.5)
 			Velocity.Z += DodgeSpeedZ*0.5;
     }
@@ -2648,7 +2754,6 @@ function bool PerformDodge(eDoubleClickDir DoubleClickMove, vector Dir, vector C
     {
         DodgeGroundSpeed = class'BallisticReplicationInfo'.default.PlayerGroundSpeed;
     }
-
     Velocity = DodgeSpeedFactor * DodgeGroundSpeed * Dir + (Velocity Dot Cross) * Cross;
 
 	// clamp dodge speed in realism and tactical
@@ -3081,7 +3186,7 @@ function ShieldViewFlash(int damage)
 {
     local int rnd;
 
-    if (BallisticPlayer(Controller) == None || damage == 0)
+    if (BallisticPlayer(Controller) == None || damage == 0 || Controller.bGodMode)
         return;
 
     rnd = FClamp(damage / 2, 25, 50);
@@ -3093,7 +3198,7 @@ function DamageViewFlash(int damage)
 {
     local int rnd;
 
-    if (BallisticPlayer(Controller) == None || damage == 0)
+    if (BallisticPlayer(Controller) == None || damage == 0 || Controller.bGodMode)
         return;
 
     rnd = FClamp(damage / 2, 25, 50);
@@ -3135,7 +3240,7 @@ simulated function DisplayDebug(Canvas Canvas, out float YL, out float YPos)
 	Canvas.DrawText(T);
 	YPos += YL;
 	Canvas.SetPos(4,YPos);
-	Canvas.DrawText("EyeHeight "$Eyeheight$" BaseEyeHeight "$BaseEyeHeight$" Physics Anim "$bPhysicsAnimUpdate);
+	Canvas.DrawText("EyeHeight "$Eyeheight$" BaseEyeHeight "$BaseEyeHeight$" Physics Anim "$bPhysicsAnimUpdate$ "Ground Speed "$GroundSpeed);
 	YPos += YL;
 	Canvas.SetPos(4,YPos);
 
@@ -3217,7 +3322,7 @@ simulated event ModifyVelocity(float DeltaTime, vector OldVelocity)
 	{
 		FSpeed = VSize(Velocity);
 			
-		if (VSize(Acceleration) < 1.00 && FSpeed > 1.00)
+		if (VSize(Acceleration) < 1.00 && FSpeed > 1.00 && Sprinter != None && !Sprinter.bIsSliding) //We don't want this when sliding
 		{
 			Control = FMin(100, FSpeed);
 				
@@ -3310,6 +3415,8 @@ defaultproperties
      //AirSpeed=270.000000
      WalkingPct=0.900000
 	 CrouchedPct=0.350000
+	 JumpCrouchPenalty=0.15
+	 JumpCrouchTime=0.30
      //DodgeSpeedFactor=1.200000
      //DodgeSpeedZ=190.000000
 

--- a/BallisticProV55/Classes/BallisticPawn.uc
+++ b/BallisticProV55/Classes/BallisticPawn.uc
@@ -2491,7 +2491,7 @@ event StartCrouch(float HeightAdjust)
 	EyeHeight += HeightAdjust;
 	OldZ -= HeightAdjust;
 	BaseEyeheight = CrouchEyeHeight;
-	TryStartSlide();
+	StartSlide();
 }
 
 event EndCrouch(float HeightAdjust)
@@ -3390,19 +3390,6 @@ simulated event ModifyVelocity(float DeltaTime, vector OldVelocity)
 	{
 		EndSlide();
 	}
-}
-
-simulated function TryStartSlide()
-{
-    if (Role < ROLE_Authority)
-        ServerStartSlide();
-    else
-        StartSlide();
-}
-
-function ServerStartSlide()
-{
-    StartSlide();
 }
 
 simulated function StartSlide()

--- a/BallisticProV55/Classes/BallisticPawn.uc
+++ b/BallisticProV55/Classes/BallisticPawn.uc
@@ -571,9 +571,6 @@ event Landed(vector HitNormal)
 
 	LastLandTime = Level.TimeSeconds;
 
-	if (Role == ROLE_Authority && Inventory != None)
-		Inventory.OwnerEvent('Landed');
-
 	// temporary hardcode
     if ( (Health > 0) && !bHidden && (Level.TimeSeconds - SplashTime > 0.25) )
 		PlayOwnedSound(GetSound(EST_Land), SLOT_Interact, 0.5, true, 30);
@@ -621,6 +618,7 @@ function PawnCheckBob(float DeltaTime, vector Y)
 		BobTime = 0;
 		WalkBob = WalkBob * (1 - FMin(1, 8 * deltatime));
 	}
+	log("BallisticPawn: PawnCheckBob: BobTime: "$BobTime$" WalkBob: "$WalkBob$" AppliedBob: "$AppliedBob$ " DeltaTime: "$DeltaTime);
 }
 
 //===========================================================================
@@ -634,7 +632,7 @@ function CheckBob(float DeltaTime, vector Y)
 	local int m,n;
 
     DeltaTime *= GroundSpeed / (class'BallisticReplicationInfo'.default.PlayerGroundSpeed * 1.5);
-
+	log("BallisticPawn: CheckBob: DeltaTime: "$DeltaTime$" GroundSpeed: "$GroundSpeed$" PlayerGroundSpeed: "$class'BallisticReplicationInfo'.default.PlayerGroundSpeed);
 	OldBobTime = BobTime;
 
 	PawnCheckBob(DeltaTime,Y);
@@ -2504,14 +2502,6 @@ event EndCrouch(float HeightAdjust)
 	CrouchEndTime = Level.TimeSeconds;
 }
 
-event Falling()
-{
-    Super.Falling();
-	if (Role == ROLE_Authority && Inventory != None)
-		Inventory.OwnerEvent('Falling');
-}
-
-
 // This is a fix for some stupid ass bug that emanates from beyond my reach.
 // It causes BaseEyeHeight to be forced to 38 on the server for non local players (unless the server player is first person spectating that client)
 simulated function vector EyePosition()
@@ -3273,13 +3263,13 @@ simulated function DisplayDebug(Canvas Canvas, out float YL, out float YPos)
 	Canvas.DrawText("FireState:"@GetEnum(enum'EFireAnimState', FireState));
 	YPos += YL;
 	Canvas.SetPos(4,YPos);
-	T = "Floor "$Floor$" DesiredSpeed "$DesiredSpeed$" Crouched "$bIsCrouched$" Try to uncrouch "$UncrouchTime;
+	T = "Floor "$Floor$" DesiredSpeed "$DesiredSpeed$" Crouched "$bIsCrouched$" Try to uncrouch "$UncrouchTime$ " GroundSpeed "$GroundSpeed$ " WalkBob "$WalkBob;
 	if ( (OnLadder != None) || (Physics == PHYS_Ladder) )
 		T=T$" on ladder "$OnLadder;
 	Canvas.DrawText(T);
 	YPos += YL;
 	Canvas.SetPos(4,YPos);
-	Canvas.DrawText("EyeHeight "$Eyeheight$" BaseEyeHeight "$BaseEyeHeight$" Physics Anim "$bPhysicsAnimUpdate$ "Ground Speed "$GroundSpeed);
+	Canvas.DrawText("EyeHeight "$Eyeheight$" BaseEyeHeight "$BaseEyeHeight$" Physics Anim "$bPhysicsAnimUpdate$ " Sliding "$bIsSliding$" SlideVelocity "$Vsize(SlideVelocity)$" SlideStartSpeed "$SlideStartSpeed$" SlideStopSpeed "$SlideStopSpeed$" MaxSlideSpeed "$MaxSlideSpeed);
 	YPos += YL;
 	Canvas.SetPos(4,YPos);
 
@@ -3456,10 +3446,13 @@ simulated function EndSlide()
 			bWaitForAnim = true;
 		AnimAction = Anim;
 	}
-    bIsSliding = false;
-    SlideVelocity = vect(0,0,0);
-    LastSlideEndTime = Level.TimeSeconds;
-    GroundSpeed = Sprinter.BaseGroundSpeed;
+	bIsSliding = false;
+	SlideVelocity = vect(0,0,0);
+	LastSlideEndTime = Level.TimeSeconds;
+	if(Role == ROLE_Authority)
+    {
+        GroundSpeed = Sprinter.BaseGroundSpeed;
+    }
 }
 
 simulated function TickSlopeCalculation(float DT)
@@ -3501,7 +3494,6 @@ simulated function HandleSliding(float DT)
 			GravityAlongSlope *= 0.5; 
 		}
 	}
-	
 	// If going downhill, accelerate; if uphill, decelerate
 	SlideVelocity += DownSlopeVect * GravityAlongSlope * 1.5 * DT;
 
@@ -3517,7 +3509,6 @@ simulated function HandleSliding(float DT)
 	Anim = SlideAnims[Get4WayDirection()];
 	LoopAnim(Anim, 1.0, 0.2);
 }
-
 
 defaultproperties
 {

--- a/BallisticProV55/Classes/BallisticPawn.uc
+++ b/BallisticProV55/Classes/BallisticPawn.uc
@@ -179,7 +179,6 @@ var vector SlideVelocity;		// Velocity during the slide
 var float SlideStartSpeed;		 // Speed required to start sliding
 var float SlideStopSpeed;		 // Speed below which sliding stops
 var float MaxSlideSpeed;		// Maximum speed during sliding, our groundspeed becomes this in order to move faster
-var float SlideEyeHeight;		 // Eye height during sliding, used to adjust camera position
 
 // Slope/Physics Calculations
 var float SlopeAngleRad;		 // Angle of the slope in radians
@@ -3375,15 +3374,14 @@ simulated event ModifyVelocity(float DeltaTime, vector OldVelocity)
 			}
 		}
 
-		SlideEyeHeight = BaseEyeHeight;
 
 		if (bIsSliding)
 		{
 			HandleSliding(DeltaTime);
-			EyeHeight = SlideEyeHeight * 0.6; // Lower eye height while sliding
 		}
 		else
 		{
+			// This isn't the best way to do this, but it works for now
 			SlideStartSpeed = class'BallisticReplicationInfo'.default.PlayerGroundSpeed*1.1;
 			SlideStopSpeed = class'BallisticReplicationInfo'.default.PlayerGroundSpeed*0.2;
 			MaxSlideSpeed = class'BallisticReplicationInfo'.default.PlayerGroundSpeed*2.5;
@@ -3392,19 +3390,15 @@ simulated event ModifyVelocity(float DeltaTime, vector OldVelocity)
 			if (bIsCrouched)
 			{
 				CrouchedPct = default.CrouchedPct;
-				EyeHeight = Lerp(DeltaTime * 1.5, EyeHeight, SlideEyeHeight, true);
 			}
 		}
 
 		OldMovementSpeed = VSize(Velocity);
 	}
 	// End slide if crouch released, speed too low, or airborne
-	if (Role == ROLE_Authority)
+	if (bIsSliding && (!bIsCrouched || VSize(SlideVelocity) < SlideStopSpeed || Physics != PHYS_Walking))
 	{
-		if (bIsSliding && (!bIsCrouched || VSize(SlideVelocity) < SlideStopSpeed || Physics != PHYS_Walking))
-		{
-			EndSlide();
-		}
+		EndSlide();
 	}
 }
 
@@ -3421,7 +3415,7 @@ function ServerStartSlide()
     StartSlide();
 }
 
-function StartSlide()
+simulated function StartSlide()
 {
     local name Anim;
 
@@ -3451,7 +3445,7 @@ function StartSlide()
     }
 }
 
-function EndSlide()
+simulated function EndSlide()
 {
 	local name Anim;
 

--- a/BallisticProV55/Classes/BallisticPawn.uc
+++ b/BallisticProV55/Classes/BallisticPawn.uc
@@ -168,8 +168,8 @@ var 	float 				MyFriction, OldMovementSpeed;
 var     bool                bCanDodge;
 
 //Wall running stuff
-var bool bLockedToSurface; // Tracks if the player is locked to a surface
-var vector LockedSurfaceNormal; // Stores the normal of the locked surface
+//var bool bLockedToSurface; // Tracks if the player is locked to a surface
+//var vector LockedSurfaceNormal; // Stores the normal of the locked surface
 
 // --- Crouch/Jump Parameters ---
 var float  CrouchEndTime;
@@ -1612,13 +1612,13 @@ simulated function ReceiveHitInfo(NetHitInfo PHI)
 simulated event Tick(float DT)
 {
 	local int Index, i, Diff;
-	local vector TraceStart, TraceEnd, HitLocation, HitNormal;
-    local Actor HitActor;
-	local Vector X,Y,Z;
+	//local vector TraceStart, TraceEnd, HitLocation, HitNormal;
+    //local Actor HitActor;
+	//local Vector X,Y,Z;
 
 	super.Tick(DT);
 
-	GetAxes(Rotation, X, Y, Z);
+	//GetAxes(Rotation, X, Y, Z);
 	
 	if (bPendingNegation)
 	{
@@ -1659,7 +1659,7 @@ simulated event Tick(float DT)
 				NewDeResFinalBlends[i].AlphaRef = Index;
 		}
 	}
-
+	/* 
 	if (bLockedToSurface)
 	{
 		// Perform a trace to check if the player is still near the wall
@@ -1679,15 +1679,16 @@ simulated event Tick(float DT)
 			StopWallRun();
 		}
 	}
+	*/
 }
-
+/* 
 simulated function StopWallRun()
 {
 	bLockedToSurface = false;
 	LockedSurfaceNormal = vect(0, 0, 0);
 	//AirControl = default.AirControl; // Reset air control
 }
-
+*/
 // Return true if the input bone is already dismembered
 simulated function bool BoneDismembered (name Bone)
 {
@@ -2497,7 +2498,7 @@ function DoDoubleJump( bool bUpdating )
         SetPhysics(PHYS_Falling);
         if ( !bUpdating )
 			PlayOwnedSound(GetSound(EST_DoubleJump), SLOT_Pain, GruntVolume, , GruntRadius);
-		StopWallRun();
+		//StopWallRun();
     }
 
 	if (Role == ROLE_Authority)
@@ -2598,9 +2599,9 @@ function bool CanMultiJump()
 
 function bool Dodge(eDoubleClickDir DoubleClickMove)
 {
-    local vector X, Y, Z, TraceStart, TraceEnd, Dir, HitLocation, HitNormal;
-    local Actor HitActor;
-    local rotator TurnRot;
+    //local vector X, Y, Z, TraceStart, TraceEnd, Dir, HitLocation, HitNormal;
+    //local Actor HitActor;
+    //local rotator TurnRot;
 
 	if (!bCanDodge)
 		return false;
@@ -2617,6 +2618,7 @@ function bool Dodge(eDoubleClickDir DoubleClickMove)
         return true;
     }
 
+	/* 
     TurnRot.Yaw = Rotation.Yaw;
     GetAxes(TurnRot, X, Y, Z);
 
@@ -2640,6 +2642,7 @@ function bool Dodge(eDoubleClickDir DoubleClickMove)
             LockedSurfaceNormal = HitNormal;
         }
     }
+	*/
 
     return false;
 }
@@ -2691,7 +2694,7 @@ function bool DoJump( bool bUpdating )
 		if ( !bUpdating )
 			PlayOwnedSound(GetSound(EST_Jump), SLOT_Pain, GruntVolume,,80);
 		JumpZ = OldJumpZ;
-		StopWallRun();
+		//StopWallRun();
         return true;
 	}
 	JumpZ = OldJumpZ;

--- a/BallisticProV55/Classes/BallisticPawn.uc
+++ b/BallisticProV55/Classes/BallisticPawn.uc
@@ -176,7 +176,6 @@ var float  CrouchEndTime;
 var() float JumpCrouchPenalty;   // Jump height multiplier for crouching
 var() float JumpCrouchTime;
 
-
 replication
 {
 	reliable if (Role == ROLE_Authority)
@@ -538,7 +537,7 @@ event Landed(vector HitNormal)
 
     MultiJumpRemaining = MaxMultiJump;
 
-	if (Role == ROLE_Authority)
+	if (Role == ROLE_Authority && Inventory != None)
 		Inventory.OwnerEvent('Landed');
 
 	// temporary hardcode
@@ -2471,7 +2470,7 @@ event EndCrouch(float HeightAdjust)
 event Falling()
 {
     Super.Falling();
-	if (Role == ROLE_Authority)
+	if (Role == ROLE_Authority && Inventory != None)
 		Inventory.OwnerEvent('Falling');
 }
 
@@ -2692,7 +2691,7 @@ function bool DoJump( bool bUpdating )
 	
 		SetPhysics(PHYS_Falling);
 		if ( !bUpdating )
-			PlayOwnedSound(GetSound(EST_Jump), SLOT_Pain, GruntVolume,,80);
+			PlayOwnedSound(GetSound(EST_Jump), SLOT_Pain, GruntVolume,,GruntRadius);
 		JumpZ = OldJumpZ;
 		//StopWallRun();
         return true;

--- a/BallisticProV55/Classes/BallisticPawn.uc
+++ b/BallisticProV55/Classes/BallisticPawn.uc
@@ -3373,7 +3373,7 @@ simulated event ModifyVelocity(float DeltaTime, vector OldVelocity)
 		{
 			// This isn't the best way to do this, but it works for now
 			SlideStartSpeed = class'BallisticReplicationInfo'.default.PlayerGroundSpeed*1.1;
-			SlideStopSpeed = class'BallisticReplicationInfo'.default.PlayerGroundSpeed*0.2;
+			SlideStopSpeed = class'BallisticReplicationInfo'.default.PlayerGroundSpeed*0.1;
 			MaxSlideSpeed = class'BallisticReplicationInfo'.default.PlayerGroundSpeed*2.5;
 			if(Level.TimeSeconds > LastLandTime + 0.1)
 				LastFallingVelocity = vect(0,0,0); 
@@ -3407,7 +3407,7 @@ simulated function StartSlide()
     {
 		Sprinter.DelayRecharge();
 		Sprinter.StopSprint();
-		SlideVelocity = Velocity * 0.5 + LastFallingVelocity * 0.5; //Blend current velocity with last falling velocity
+		SlideVelocity = Velocity + LastFallingVelocity * 0.5; //Blend current velocity with last falling velocity
 		SlideVelocity += Normal(SlideVelocity) * FMax(SlidePower*0.5,SlidePower * (Sprinter.Stamina / Sprinter.MaxStamina));
 		// Clamp slide velocity to max speed
         if (VSize(SlideVelocity) > MaxSlideSpeed)
@@ -3489,7 +3489,8 @@ simulated function HandleSliding(float DT)
 		SlideVelocity -= Normal(SlideVelocity) * DynamicFriction * -PhysicsVolume.Gravity.Z * Cos(SlopeAngleRad) * DT;
 
 	// Apply slide velocity to pawn, handle this on the pawn instead
-	Velocity = Velocity * 0.3 + SlideVelocity * 0.7;
+	Velocity = SlideVelocity;
+
 	if (VSize(Velocity) > MaxSlideSpeed)
 		Velocity = Normal(Velocity) * MaxSlideSpeed;
 

--- a/BallisticProV55/Classes/BallisticPlayer.uc
+++ b/BallisticProV55/Classes/BallisticPlayer.uc
@@ -1236,6 +1236,27 @@ ignores SeePlayer, HearNoise, Bump, ServerSpectate;
     }
 }
 
+state PlayerWallRunning extends PlayerWalking
+{
+
+}
+
+function AdjustViewForWall(vector WallNormal, float DeltaTime)
+{
+    local rotator ViewRotation;
+    local float DesiredRoll;
+
+    // Calculate roll based on wall normal
+    DesiredRoll = -WallNormal.Y * 300; // Roll based on wall's steepness
+
+    // Smoothly interpolate roll
+    ViewRotation = Rotation;
+    ViewRotation.Roll = Lerp(DeltaTime, ViewRotation.Roll, DesiredRoll);
+
+    // Apply the updated rotation
+    SetRotation(ViewRotation);
+    Pawn.FaceRotation(ViewRotation, DeltaTime);
+}
 // end Titan RPG handling
 
 /*
@@ -1274,6 +1295,9 @@ function ViewFlash(float DeltaTime)
 
 function ClientDmgFlash( float scale, vector fog )
 {
+    if (bGodMode)
+		return;
+
 	DesiredFlashScale = scale;
 	DesiredFlashFog = 0.001 * fog;
 }
@@ -1281,6 +1305,9 @@ function ClientDmgFlash( float scale, vector fog )
 // disallow scaling flash
 function ClientFlash( float scale, vector fog )
 {
+    if (bGodMode)
+		return;
+
     FlashScale = scale * vect(1,1,1);
     flashfog = 0.001 * fog;
 	bOverrideDmgFlash = true;

--- a/BallisticProV55/Classes/BallisticPlayer.uc
+++ b/BallisticProV55/Classes/BallisticPlayer.uc
@@ -1236,27 +1236,6 @@ ignores SeePlayer, HearNoise, Bump, ServerSpectate;
     }
 }
 
-state PlayerWallRunning extends PlayerWalking
-{
-
-}
-
-function AdjustViewForWall(vector WallNormal, float DeltaTime)
-{
-    local rotator ViewRotation;
-    local float DesiredRoll;
-
-    // Calculate roll based on wall normal
-    DesiredRoll = -WallNormal.Y * 300; // Roll based on wall's steepness
-
-    // Smoothly interpolate roll
-    ViewRotation = Rotation;
-    ViewRotation.Roll = Lerp(DeltaTime, ViewRotation.Roll, DesiredRoll);
-
-    // Apply the updated rotation
-    SetRotation(ViewRotation);
-    Pawn.FaceRotation(ViewRotation, DeltaTime);
-}
 // end Titan RPG handling
 
 /*

--- a/BallisticProV55/Classes/ClientTeamOutfittingInterface.uc
+++ b/BallisticProV55/Classes/ClientTeamOutfittingInterface.uc
@@ -250,11 +250,6 @@ function SendWeapons ()
 	local array<string> Weaps;
 	local array<byte>	RedBoxes, BlueBoxes;
 
-	// Resize arrays to accommodate all weapons
-    RedBoxes.Length = Mut.RedLoadoutGroup0.Length + Mut.RedLoadoutGroup1.Length + Mut.RedLoadoutGroup2.Length + Mut.RedLoadoutGroup3.Length + Mut.RedLoadoutGroup4.Length;
-    BlueBoxes.Length = Mut.BlueLoadoutGroup0.Length + Mut.BlueLoadoutGroup1.Length + Mut.BlueLoadoutGroup2.Length + Mut.BlueLoadoutGroup3.Length + Mut.BlueLoadoutGroup4.Length;
-
-
 	//Go through the available loadout weapons, adding them to the Weaps array. Continue if there is no weapon in the slot
 	for (i=0;i<Mut.RedLoadoutGroup0.length;i++)
 	{
@@ -421,7 +416,6 @@ simulated function ReceiveWeapon (string WeaponName, byte RedBoxes, byte BlueBox
 	if (bTerminate)
     {
         SortLists();
-
 		bWeaponsReady = true;
     }
 }
@@ -443,7 +437,6 @@ function bool LoadWIFromCache(string ClassStr, out BC_WeaponInfoCache.WeaponInfo
 simulated function SortLists()
 {
     local int team, group_index;
-
     for (team = 0; team < 2; ++team)
     {
         for (group_index = 0; group_index < 5; ++group_index)
@@ -507,7 +500,6 @@ simulated function SortList(byte group_index, byte team)
             }
 
 		}
-
         else 
             Log("ClientTeamOutfittingInterface: Failed to load "$ GetGroupItemForTeam(group_index, team, i) $" from cache");
 	}

--- a/BallisticProV55/Classes/ClientTeamOutfittingInterface.uc
+++ b/BallisticProV55/Classes/ClientTeamOutfittingInterface.uc
@@ -250,6 +250,11 @@ function SendWeapons ()
 	local array<string> Weaps;
 	local array<byte>	RedBoxes, BlueBoxes;
 
+	// Resize arrays to accommodate all weapons
+    RedBoxes.Length = Mut.RedLoadoutGroup0.Length + Mut.RedLoadoutGroup1.Length + Mut.RedLoadoutGroup2.Length + Mut.RedLoadoutGroup3.Length + Mut.RedLoadoutGroup4.Length;
+    BlueBoxes.Length = Mut.BlueLoadoutGroup0.Length + Mut.BlueLoadoutGroup1.Length + Mut.BlueLoadoutGroup2.Length + Mut.BlueLoadoutGroup3.Length + Mut.BlueLoadoutGroup4.Length;
+
+
 	//Go through the available loadout weapons, adding them to the Weaps array. Continue if there is no weapon in the slot
 	for (i=0;i<Mut.RedLoadoutGroup0.length;i++)
 	{

--- a/BallisticProV55/Classes/ConfigTab_GameplayPrefs.uc
+++ b/BallisticProV55/Classes/ConfigTab_GameplayPrefs.uc
@@ -49,6 +49,7 @@ function SaveSettings()
     class'BallisticWeapon'.default.ScopeHandling		= EScopeHandling(co_ADSHandling.GetIndex());
 	class'BallisticWeapon'.default.ModeHandling			= ModeSaveType(co_ModeMemory.GetIndex());
 	class'BallisticPlayer'.default.ZoomTimeMod			= fl_ZoomTimeMod.GetValue();
+    class'BallisticWeapon'.default.ZoomTimeMod			= fl_ZoomTimeMod.GetValue();
 	class'BallisticPlayer'.default.bUseWeaponUI 			= ch_WeaponUI.IsChecked();
 	class'BallisticDamageType'.default.bSimpleDeathMessages	= ch_SimpleDeathMessages.IsChecked();
 	class'BallisticDamageType'.default.bLessDisruptiveFlash	= ch_LessDisruptiveFlash.IsChecked();
@@ -109,7 +110,7 @@ defaultproperties
 
 	 Begin Object Class=moFloatEdit Name=fl_ZoomTimeModFloat
          MinValue=1.000000
-         MaxValue=4.000000
+         MaxValue=5.000000
          ComponentJustification=TXTA_Left
          CaptionWidth=0.700000
          Caption="Zoom Time Mod"

--- a/BallisticProV55/Classes/ConfigTab_Loadout.uc
+++ b/BallisticProV55/Classes/ConfigTab_Loadout.uc
@@ -456,8 +456,6 @@ function bool InternalOnClick(GUIComponent Sender)
 				}
 			}
 		}
-		else
-			DisplayWeapon();
 	}
 	else if (Sender == BAddAll)				// FILL
 	{

--- a/BallisticProV55/Classes/ConfigTab_MovementRules.uc
+++ b/BallisticProV55/Classes/ConfigTab_MovementRules.uc
@@ -10,7 +10,7 @@ var automated moFloatEdit       fe_PlayerStrafeScale;		// Strafe Scale
 var automated moFloatEdit       fe_PlayerBackpedalScale;	// Backwards Strafe Scale
 var automated moCheckbox		ch_AllowDodging;			// Enables Dodging
 var automated moCheckbox		ch_AllowDoubleJump;			// Enables Double Jump
-
+var automated moCheckBox        cb_AllowCrouchSliding;				// Enable Sprint
 var automated moCheckBox        cb_bUseSprint;				// Enable Sprint
 var automated moNumericEdit     ne_StaminaDrainRate;		// Stamina Drain Rate
 var automated moNumericEdit     ne_StaminaChargeRate;		// Stamina Charge Rate
@@ -37,7 +37,7 @@ function LoadSettings()
     	fe_PlayerBackpedalScale.SetValue(game_style.default.PlayerBackpedalScale);
 		ch_AllowDodging.Checked(game_style.default.bAllowDodging);
 		ch_AllowDoubleJump.Checked(game_style.default.bAllowDoubleJump);
-
+        cb_AllowCrouchSliding.Checked(game_style.default.bAllowCrouchSliding);
 		cb_bUseSprint.Checked(game_style.default.bEnableSprint);
     	ne_StaminaDrainRate.SetValue(game_style.default.StaminaDrainRate);
     	ne_StaminaChargeRate.SetValue(game_style.default.StaminaChargeRate);
@@ -57,7 +57,7 @@ function DefaultSettings()
     fe_PlayerBackpedalScale.SetValue(1);
 	ch_AllowDodging.Checked(true);
 	ch_AllowDoubleJump.Checked(true);
-
+    cb_AllowCrouchSliding.Checked(true);
 	cb_bUseSprint.Checked(true);
     ne_StaminaDrainRate.SetValue(25);
     ne_StaminaChargeRate.SetValue(25);
@@ -85,7 +85,7 @@ function SaveSettings()
     	game_style.default.PlayerBackpedalScale 	= fe_PlayerBackpedalScale.GetValue();
 		game_style.default.bAllowDodging			= ch_AllowDodging.IsChecked();
 		game_style.default.bAllowDoubleJump 		= ch_AllowDoubleJump.IsChecked();
-
+        game_style.default.bAllowCrouchSliding 	= cb_AllowCrouchSliding.IsChecked();
 		game_style.default.bEnableSprint 		= cb_bUseSprint.IsChecked();
     	game_style.default.StaminaDrainRate 		= ne_StaminaDrainRate.GetValue();
     	game_style.default.StaminaChargeRate 	= ne_StaminaChargeRate.GetValue();
@@ -192,12 +192,23 @@ defaultproperties
      End Object
      ch_AllowDoubleJump=moCheckBox'ch_AllowDoubleJumpCheck'
 
+    Begin Object Class=moCheckBox Name=cb_AllowCrouchSlidingC
+        ComponentWidth=0.175000
+        Caption="Enable Crouch Sliding"
+        OnCreateComponent=cb_AllowCrouchSlidingC.InternalOnCreateComponent
+        Hint="Enables crouch sliding."
+        WinTop=0.500000
+        WinLeft=0.250000
+        WinHeight=0.040000
+    End Object
+    cb_AllowCrouchSliding=moCheckBox'cb_AllowCrouchSlidingC'
+
 	 Begin Object Class=moCheckBox Name=cb_bUseSprintC
          ComponentWidth=0.175000
          Caption="Enable Sprint"
          OnCreateComponent=cb_bUseSprintC.InternalOnCreateComponent
          Hint="Enables sprint."
-         WinTop=0.50000
+         WinTop=0.550000
          WinLeft=0.250000
          WinHeight=0.040000
      End Object
@@ -211,7 +222,7 @@ defaultproperties
          Caption="Stamina Drain % Per Second"
          OnCreateComponent=ne_StaminaDrainRateC.InternalOnCreateComponent
          Hint="Percentage of stamina to drain every second when sprinting."
-         WinTop=0.550000
+         WinTop=0.600000
          WinLeft=0.250000
          WinHeight=0.040000
      End Object
@@ -225,7 +236,7 @@ defaultproperties
          Caption="Stamina Regen % Per Second"
          OnCreateComponent=ne_StaminaChargeRateC.InternalOnCreateComponent
          Hint="Percentage of stamina to regenerate every second when not sprinting."
-         WinTop=0.60000
+         WinTop=0.650000
          WinLeft=0.250000
          WinHeight=0.040000
      End Object
@@ -239,7 +250,7 @@ defaultproperties
          Caption="Sprint Speed Multiplier"
          OnCreateComponent=fe_InitSpeedFactorC.InternalOnCreateComponent
          Hint="The speed multiplier during sprint."
-         WinTop=0.650000
+         WinTop=0.700000
          WinLeft=0.250000
          WinHeight=0.040000
      End Object
@@ -252,7 +263,7 @@ defaultproperties
          Caption="Jump Drain"
          OnCreateComponent=fe_JumpDrainC.InternalOnCreateComponent
          Hint="The amount of stamina we lose when we jump."
-         WinTop=0.70000
+         WinTop=0.750000
          WinLeft=0.250000
          WinHeight=0.040000
      End Object
@@ -266,7 +277,7 @@ defaultproperties
          Caption="Stamina Recharge Delay"
          OnCreateComponent=fe_StaminaRechargeDelayC.InternalOnCreateComponent
          Hint="The delay before stamina starts to recharge."
-         WinTop=0.750000
+         WinTop=0.800000
          WinLeft=0.250000
          WinHeight=0.040000
      End Object

--- a/BallisticProV55/Classes/ConfigTab_MovementRules.uc
+++ b/BallisticProV55/Classes/ConfigTab_MovementRules.uc
@@ -15,7 +15,8 @@ var automated moCheckBox        cb_bUseSprint;				// Enable Sprint
 var automated moNumericEdit     ne_StaminaDrainRate;		// Stamina Drain Rate
 var automated moNumericEdit     ne_StaminaChargeRate;		// Stamina Charge Rate
 var automated moFloatEdit       fe_InitSpeedFactor;			// Speed During Sprint
-var automated moFloatEdit       fe_JumpDrain;			// Jump Drain Factor
+var automated moFloatEdit       fe_JumpDrain;			    // Jump Drain Factor
+var automated moFloatEdit       fe_StaminaRechargeDelay;	// Stamina Recharge Delay
 
 //==================================================================
 // Settings & Defaults
@@ -42,6 +43,7 @@ function LoadSettings()
     	ne_StaminaChargeRate.SetValue(game_style.default.StaminaChargeRate);
     	fe_InitSpeedFactor.SetValue(game_style.default.SprintSpeedFactor);
     	fe_JumpDrain.SetValue(game_style.default.JumpDrain);
+    	fe_StaminaRechargeDelay.SetValue(game_style.default.StaminaRechargeDelay);
 	}
 }
 
@@ -61,6 +63,7 @@ function DefaultSettings()
     ne_StaminaChargeRate.SetValue(25);
     fe_InitSpeedFactor.SetValue(1.35);
     fe_JumpDrain.SetValue(2);
+    fe_StaminaRechargeDelay.SetValue(1.5);
 }
 
 function SaveSettings()
@@ -86,6 +89,7 @@ function SaveSettings()
 		game_style.default.bEnableSprint 		= cb_bUseSprint.IsChecked();
     	game_style.default.StaminaDrainRate 		= ne_StaminaDrainRate.GetValue();
     	game_style.default.StaminaChargeRate 	= ne_StaminaChargeRate.GetValue();
+        game_style.default.StaminaRechargeDelay 	= fe_StaminaRechargeDelay.GetValue();
     	game_style.default.SprintSpeedFactor 	= fe_InitSpeedFactor.GetValue();
     	game_style.default.JumpDrain 		= fe_JumpDrain.GetValue();
 
@@ -97,12 +101,12 @@ defaultproperties
 {	 
      Begin Object Class=moNumericEdit Name=ne_PlayerGroundSpeedC
          MinValue=160
-         MaxValue=440
+         MaxValue=1000
          Step=20
          ComponentWidth=0.175000
          Caption="Movement Speed"
          OnCreateComponent=ne_PlayerGroundSpeedC.InternalOnCreateComponent
-         Hint="Player ground and air speed. 160 - 440. 440 is UT2004 default."
+         Hint="Player ground and air speed. 160 - 1000. 440 is UT2004 default."
          WinTop=0.10000
          WinLeft=0.250000
          WinHeight=0.040000
@@ -111,12 +115,12 @@ defaultproperties
 
      Begin Object Class=moNumericEdit Name=ne_PlayerAccelRateC
          MinValue=1024
-         MaxValue=2048
+         MaxValue=4096
         Step=256
          ComponentWidth=0.175000
          Caption="Acceleration Rate"
          OnCreateComponent=ne_PlayerAccelRateC.InternalOnCreateComponent
-         Hint="Scales player acceleration. 1024 - 2048. UT2004 is 2048."
+         Hint="Scales player acceleration. 1024 - 4096. UT2004 is 2048."
          WinTop=0.15000
          WinLeft=0.250000
          WinHeight=0.040000
@@ -228,8 +232,8 @@ defaultproperties
      ne_StaminaChargeRate=moNumericEdit'ne_StaminaChargeRateC'
 
      Begin Object Class=moFloatEdit Name=fe_InitSpeedFactorC
-         MinValue=1.250000
-         MaxValue=1.500000
+         MinValue=1.100000
+         MaxValue=2.500000
          Step=0.05
          ComponentWidth=0.175000
          Caption="Sprint Speed Multiplier"
@@ -243,15 +247,29 @@ defaultproperties
 
      Begin Object Class=moFloatEdit Name=fe_JumpDrainC
          MinValue=0.000000
-         MaxValue=2.000000
+         MaxValue=10.000000
          ComponentWidth=0.175000
-         Caption="Jump Drain Factor"
+         Caption="Jump Drain"
          OnCreateComponent=fe_JumpDrainC.InternalOnCreateComponent
-         Hint="The jump drain factor during sprint."
+         Hint="The amount of stamina we lose when we jump."
          WinTop=0.70000
          WinLeft=0.250000
          WinHeight=0.040000
      End Object
      fe_JumpDrain=moFloatEdit'fe_JumpDrainC'
+
+     Begin Object Class=moFloatEdit Name=fe_StaminaRechargeDelayC
+         MinValue=0.000000
+         MaxValue=5.000000
+         Step=0.1
+         ComponentWidth=0.175000
+         Caption="Stamina Recharge Delay"
+         OnCreateComponent=fe_StaminaRechargeDelayC.InternalOnCreateComponent
+         Hint="The delay before stamina starts to recharge."
+         WinTop=0.750000
+         WinLeft=0.250000
+         WinHeight=0.040000
+     End Object
+     fe_StaminaRechargeDelay=moFloatEdit'fe_StaminaRechargeDelayC'
 
 }

--- a/BallisticProV55/Classes/ConfigTab_Swappings.uc
+++ b/BallisticProV55/Classes/ConfigTab_Swappings.uc
@@ -39,19 +39,131 @@ struct SwapPreset			// A single preset
 var() config array<Swap>		DefaultSwaps;			// The default replacements for the old items
 var() config bool				bDefaultsWritten;		// The defaults have been written to the ini file. Don't do it again
 
+var array<string> TempItems; // Temporary array to store items for sorting
+
+var() localized string 		Headings[12];
+
 function InitializeConfigTab()
 {
 	local int i, j;
 	local array<CacheManager.WeaponRecord> Recs;
-	local BC_WeaponInfoCache.WeaponInfo WI;
-	local array<String> PresetNames;
+	local string s;
+	local int Index[12];
+	local bool OtherLoaded, MiscLoaded;
+    local BC_WeaponInfoCache.WeaponInfo WI, TempItemName;
+    local array<String> PresetNames;
+    local array<BC_WeaponInfoCache.WeaponInfo> TempItemNameList;
 
-	// Fill old items list
-	for (i=0;i<class'Mut_BallisticSwap'.static.GetNumWeapons();i++)
-		lb_OldWeapons.List.Add(class'Mut_BallisticSwap'.static.GetOldWeaponClass(i).default.ItemName, , string(class'Mut_BallisticSwap'.static.GetOldWeaponClass(i)));
-	lb_OldWeapons.List.OnClick = InternalOnClick;
+	lb_NewWeapons.CheckList.Add(Headings[0],,"MELEE",true);
+	lb_NewWeapons.CheckList.Add(Headings[1],,"SIDEARM",true);
+	lb_NewWeapons.CheckList.Add(Headings[2],,"SPREAD",true);
+	lb_NewWeapons.CheckList.Add(Headings[3],,"SMG",true);
+	lb_NewWeapons.CheckList.Add(Headings[4],,"AR",true);
+	lb_NewWeapons.CheckList.Add(Headings[5],,"MG",true);
+	lb_NewWeapons.CheckList.Add(Headings[6],,"SNIPER",true);
+	lb_NewWeapons.CheckList.Add(Headings[7],,"HEAVY",true);
+	lb_NewWeapons.CheckList.Add(Headings[8],,"SPECIAL",true);
+	lb_NewWeapons.CheckList.Add(Headings[9],,"TRAPS",true);
 
-	// Fill replacement items list
+    // Fill old items list
+    for (i = 0; i < class'Mut_BallisticSwap'.static.GetNumWeapons(); i++)
+        lb_OldWeapons.List.Add(class'Mut_BallisticSwap'.static.GetOldWeaponClass(i).default.ItemName, , string(class'Mut_BallisticSwap'.static.GetOldWeaponClass(i)));
+    lb_OldWeapons.List.OnClick = InternalOnClick;
+
+	for (j=0;j<12;j++)
+		Index[j] = j+1;
+
+	class'CacheManager'.static.GetWeaponList(Recs);
+	// Fill replacement items list in a temporary list
+	for (i=0;i<Recs.Length;i++)
+	{
+		if (!class'BC_WeaponInfoCache'.static.IsValid(Recs[i].ClassName))
+			continue;
+		// Tap into the BW weapon cache system to identify BallisticWeapons without loading them
+		WI = class'BC_WeaponInfoCache'.static.AutoWeaponInfo(Recs[i].ClassName, j);
+		if (j == -1)
+			continue;
+        TempItemNameList[i] = WI; // Store them all here
+    }
+    // Sort the list alphabetically by ItemName using bubble sort
+    for (i = 0; i < TempItemNameList.Length - 1; i++)
+    {
+        for (j = 0; j < TempItemNameList.Length - i - 1; j++)
+        {
+            if (TempItemNameList[j].ItemName > TempItemNameList[j + 1].ItemName)
+            {
+                // Swap items
+                TempItemName = TempItemNameList[j];
+                TempItemNameList[j] = TempItemNameList[j + 1];
+                TempItemNameList[j + 1] = TempItemName;
+            }
+        }
+    }
+        //Then add the item to the checklist
+    for (i = 0; i < TempItemNameList.Length; i++)
+    {
+		if (TempItemNameList[i].ClassName != "")
+		{
+			if (TempItemNameList[i].bIsBW)
+			{
+				if (TempItemNameList[i].InventoryGroup > 0 && TempItemNameList[i].InventoryGroup < 10)
+				{
+					lb_NewWeapons.CheckList.Insert(Index[TempItemNameList[i].InventoryGroup-1], TempItemNameList[i].ItemName,, TempItemNameList[i].ClassName);
+					for (j=TempItemNameList[i].InventoryGroup-1;j<12;j++)
+						Index[j]++;
+				}
+				else if (TempItemNameList[i].InventoryGroup == 0)
+				{
+					lb_NewWeapons.CheckList.Insert(Index[9], TempItemNameList[i].ItemName,, TempItemNameList[i].ClassName);
+
+					for (j=9;j<12;j++)
+						Index[j]++;
+				}
+				else
+				{
+					if (!MiscLoaded)
+					{
+						MiscLoaded=true;
+						lb_NewWeapons.CheckList.Add(Headings[10],,"MISC",true);
+					}
+					lb_NewWeapons.CheckList.Insert(Index[10], TempItemNameList[i].ItemName,, TempItemNameList[i].ClassName);
+					Index[10]++;
+					Index[11]++;
+				}
+ 			}
+		}
+	}
+	class'BC_WeaponInfoCache'.static.EndSession();
+
+	if ((lb_NewWeapons.CheckList.Index == 0 && lb_NewWeapons.CheckList.IsSection()) || lb_NewWeapons.CheckList.Index >= lb_NewWeapons.CheckList.ItemCount)
+		lb_NewWeapons.CheckList.SetIndex(1);
+
+	SaveConfig();
+	lb_NewWeapons.CheckList.OnClick = InternalOnClick;
+
+    PresetNames = GetPerObjectNames("BallisticProV55", "BallisticSwapPreset");
+    for (i = 0; i < PresetNames.Length; i++)
+        cb_Presets.AddItem(PresetNames[i], new(None, PresetNames[i]) class'BallisticSwapPreset',);
+    cb_Presets.SetIndex(0);
+    cb_Presets.SetText("");
+
+    ch_Independent.MyCheckBox.OnClick = InternalOnClick;
+}
+/* 
+function InitializeConfigTab()
+{
+    local int i, j;
+    local array<CacheManager.WeaponRecord> Recs;
+    local BC_WeaponInfoCache.WeaponInfo WI, TempItemName;
+    local array<String> PresetNames;
+    local array<BC_WeaponInfoCache.WeaponInfo> TempItemNameList;
+
+    // Fill old items list
+    for (i = 0; i < class'Mut_BallisticSwap'.static.GetNumWeapons(); i++)
+        lb_OldWeapons.List.Add(class'Mut_BallisticSwap'.static.GetOldWeaponClass(i).default.ItemName, , string(class'Mut_BallisticSwap'.static.GetOldWeaponClass(i)));
+    lb_OldWeapons.List.OnClick = InternalOnClick;
+
+	// Fill replacement items list in a temporary list
 	class'CacheManager'.static.GetWeaponList(Recs);
 	for (i=0;i<Recs.Length;i++)
 	{
@@ -61,25 +173,44 @@ function InitializeConfigTab()
 		WI = class'BC_WeaponInfoCache'.static.AutoWeaponInfo(Recs[i].ClassName, j);
 		if (j == -1)
 			continue;
-		if (WI.ClassName != "")
-		{
-			if (WI.bIsBW)
-				lb_NewWeapons.CheckList.AddCheck(WI.ItemName, , Recs[i].ClassName);
-		}
-	}
+        TempItemNameList[i] = WI; // Store them all here
+    }
+
+    // Sort the list alphabetically by ItemName using bubble sort
+    for (i = 0; i < TempItemNameList.Length - 1; i++)
+    {
+        for (j = 0; j < TempItemNameList.Length - i - 1; j++)
+        {
+            if (TempItemNameList[j].ItemName > TempItemNameList[j + 1].ItemName)
+            {
+                // Swap items
+                TempItemName = TempItemNameList[j];
+                TempItemNameList[j] = TempItemNameList[j + 1];
+                TempItemNameList[j + 1] = TempItemName;
+            }
+        }
+    }
+    //Then add the item to the checklist
+    for (i = 0; i < TempItemNameList.Length; i++)
+    {
+        if (TempItemNameList[i].ClassName != "")
+        {
+            lb_NewWeapons.CheckList.AddCheck(TempItemNameList[i].ItemName, , TempItemNameList[i].ClassName);
+        }
+    }
 	class'BC_WeaponInfoCache'.static.EndSession();
 	SaveConfig();
 	lb_NewWeapons.CheckList.OnClick = InternalOnClick;
 
-	PresetNames = GetPerObjectNames("BallisticProV55", "BallisticSwapPreset");
-	for (i=0;i<PresetNames.Length;i++)
-		cb_Presets.AddItem(PresetNames[i],new(None, PresetNames[i]) class'BallisticSwapPreset',);
-	cb_Presets.SetIndex(0);
-	cb_Presets.SetText("");
+    PresetNames = GetPerObjectNames("BallisticProV55", "BallisticSwapPreset");
+    for (i = 0; i < PresetNames.Length; i++)
+        cb_Presets.AddItem(PresetNames[i], new(None, PresetNames[i]) class'BallisticSwapPreset',);
+    cb_Presets.SetIndex(0);
+    cb_Presets.SetText("");
 
-	ch_Independent.MyCheckBox.OnClick = InternalOnClick;
+    ch_Independent.MyCheckBox.OnClick = InternalOnClick;
 }
-
+*/
 function InternalOnChange(GUIComponent Sender)
 {
 	if (Sender == cb_Presets && cb_Presets.GetObject() != None)
@@ -89,10 +220,35 @@ function InternalOnChange(GUIComponent Sender)
 	}
 }
 
+//===========================================================================
+// SectionCheck
+//
+// Called when a section header is checked.
+// Sets all checkboxes up until the next section, in the same column, to its own value.
+//===========================================================================
+function SectionCheck (bool bChecked, int Index)
+{
+	local int i, j;
+	for (j=Index+1;j<lb_NewWeapons.CheckList.Elements.length;j++)
+	{
+		if (lb_NewWeapons.CheckList.Elements[j].bSection)
+			return;
+
+		lb_NewWeapons.CheckList.SetChecked(j, bChecked);
+
+        // Update the Swaps array to save the selection
+        ChangeSwapListEntry(lb_OldWeapons.List.Index, lb_NewWeapons.List.Elements[j].ExtraStrData, bChecked);
+
+	}
+}
+
 function bool InternalOnClick(GUIComponent Sender)
 {
 	local int i;
 	local String s;
+	local int LastCheck;
+	local byte LastColumn;
+
 
 	// Replacement weapons list
 	if (Sender == lb_NewWeapons.CheckList)
@@ -100,6 +256,11 @@ function bool InternalOnClick(GUIComponent Sender)
 		lb_NewWeapons.CheckList.InternalOnClick(Sender);
 
 		ChangeSwapListEntry(lb_OldWeapons.List.Index, lb_NewWeapons.List.GetExtraAtIndex(lb_NewWeapons.CheckList.LastCheckChanged), lb_NewWeapons.CheckList.Checks[lb_NewWeapons.CheckList.LastCheckChanged] > 0);
+		if (lb_NewWeapons.CheckList.LastClickWasCheck)
+		{
+			if (lb_NewWeapons.CheckList.Elements[lb_NewWeapons.CheckList.LastCheckChanged].bSection)
+				SectionCheck(lb_NewWeapons.CheckList.Checks[lb_NewWeapons.CheckList.LastCheckChanged] > 0, lb_NewWeapons.CheckList.LastCheckChanged);
+		}
 	}
 	// Old weapons list
 	else if (Sender == lb_OldWeapons.List)
@@ -177,6 +338,12 @@ function ChangeSwapListEntry(int Index, string Item, bool bAdd)
 function UpdateReplacementsList(int Index)
 {
 	local int i, j;
+    // Safety check for Swaps array
+    if (Swaps.Length == 0 || Index < 0 || Index >= Swaps.Length)
+    {
+        log("Error: Swaps array is empty or Index is out of bounds. Index: " $ Index $ ", Swaps.Length: " $ Swaps.Length);
+        return;
+    }
 	for (i=0;i<lb_NewWeapons.List.Elements.Length;i++)	{
 		lb_NewWeapons.CheckList.SetChecked(i, false);
 		for (j=0;j<Swaps[Index].NIs.length;j++)
@@ -188,23 +355,36 @@ function UpdateReplacementsList(int Index)
 //Load weapons from mutator.
 function LoadSettings()
 {
-	local int i, j;
-	local array<string> NewWeaps;
-	local byte bRandom;
+    local int i, j;
+    local byte bRandom;
+    local array<string> NewWeaps; // Array to hold new weapons for each old weapon
 
-	cb_Presets.SetText("");
-	Swaps.length = 0;
-	for (i=0;i<class'Mut_BallisticSwap'.static.GetNumWeapons();i++)
-	{
-		Swaps.length = i+1;
-		NewWeaps = class'Mut_BallisticSwap'.static.GetNewWeapons(i, bRandom);
-		for (j=0;j<NewWeaps.length;j++)
-			Swaps[i].NIs[j] = NewWeaps[j];
-		Swaps[i].R = bRandom>0;
-	}
-	UpdateReplacementsList(lb_OldWeapons.List.Index);
+    log("Loading settings from mutator...");
+    cb_Presets.SetText("");
+    Swaps.Length = class'Mut_BallisticSwap'.static.GetNumWeapons(); // Resize Swaps array
 
-	nu_SwitchTime.SetValue(class'Mut_BallisticSwap'.default.PickupChangeTime);
+    // Process each weapon index
+    for (i = 0; i < Swaps.Length; i++)
+    {
+        //log("Processing weapon index: " $ i);
+        Swaps[i].R = false; // Default random spawning flag
+
+        NewWeaps = class'Mut_BallisticSwap'.static.GetNewWeapons(i, bRandom);
+        //log("NewWeaps Length for index " $ i $ ": " $ NewWeaps.Length);
+
+        Swaps[i].NIs.Length = NewWeaps.Length; // Resize Swaps[i].NIs to match NewWeaps length
+
+        for (j = 0; j < NewWeaps.Length; j++)
+        {
+            Swaps[i].NIs[j] = NewWeaps[j]; // Copy full package.classname to Swaps
+        }
+
+        Swaps[i].R = bRandom > 0; // Set random spawning flag
+    }
+
+    UpdateReplacementsList(lb_OldWeapons.List.Index);
+
+    nu_SwitchTime.SetValue(class'Mut_BallisticSwap'.default.PickupChangeTime);
 }
 
 //Send settings to mutator.
@@ -251,6 +431,7 @@ function DefaultSettings()
 
 	nu_SwitchTime.SetValue(60);
 }
+
 
 defaultproperties
 {
@@ -434,4 +615,17 @@ defaultproperties
      DefaultSwaps(13)=(NIs=("BallisticProV55.NRP57Grenade"))
      DefaultSwaps(14)=(NIs=("BallisticProV55.BX5Mine"))
      DefaultSwaps(15)=(NIs=("BallisticProV55.R78Rifle"))
+
+    Headings(0)="Melee"
+    Headings(1)="Sidearms"
+    Headings(2)="Sub Machineguns"
+    Headings(3)="Assault Rifles"
+    Headings(4)="Energy Weapons"
+    Headings(5)="Heavy Machineguns"
+    Headings(6)="Shotguns"
+    Headings(7)="Ordnance"
+    Headings(8)="Sniper Rifles"
+    Headings(9)="Grenades"
+    Headings(10)="Miscellaneous"
+    Headings(11)="Non-BW"
 }

--- a/BallisticProV55/Classes/ConfigTab_Swappings.uc
+++ b/BallisticProV55/Classes/ConfigTab_Swappings.uc
@@ -149,68 +149,7 @@ function InitializeConfigTab()
 
     ch_Independent.MyCheckBox.OnClick = InternalOnClick;
 }
-/* 
-function InitializeConfigTab()
-{
-    local int i, j;
-    local array<CacheManager.WeaponRecord> Recs;
-    local BC_WeaponInfoCache.WeaponInfo WI, TempItemName;
-    local array<String> PresetNames;
-    local array<BC_WeaponInfoCache.WeaponInfo> TempItemNameList;
 
-    // Fill old items list
-    for (i = 0; i < class'Mut_BallisticSwap'.static.GetNumWeapons(); i++)
-        lb_OldWeapons.List.Add(class'Mut_BallisticSwap'.static.GetOldWeaponClass(i).default.ItemName, , string(class'Mut_BallisticSwap'.static.GetOldWeaponClass(i)));
-    lb_OldWeapons.List.OnClick = InternalOnClick;
-
-	// Fill replacement items list in a temporary list
-	class'CacheManager'.static.GetWeaponList(Recs);
-	for (i=0;i<Recs.Length;i++)
-	{
-		if (!class'BC_WeaponInfoCache'.static.IsValid(Recs[i].ClassName))
-			continue;
-		// Tap into the BW weapon cache system to identify BallisticWeapons without loading them
-		WI = class'BC_WeaponInfoCache'.static.AutoWeaponInfo(Recs[i].ClassName, j);
-		if (j == -1)
-			continue;
-        TempItemNameList[i] = WI; // Store them all here
-    }
-
-    // Sort the list alphabetically by ItemName using bubble sort
-    for (i = 0; i < TempItemNameList.Length - 1; i++)
-    {
-        for (j = 0; j < TempItemNameList.Length - i - 1; j++)
-        {
-            if (TempItemNameList[j].ItemName > TempItemNameList[j + 1].ItemName)
-            {
-                // Swap items
-                TempItemName = TempItemNameList[j];
-                TempItemNameList[j] = TempItemNameList[j + 1];
-                TempItemNameList[j + 1] = TempItemName;
-            }
-        }
-    }
-    //Then add the item to the checklist
-    for (i = 0; i < TempItemNameList.Length; i++)
-    {
-        if (TempItemNameList[i].ClassName != "")
-        {
-            lb_NewWeapons.CheckList.AddCheck(TempItemNameList[i].ItemName, , TempItemNameList[i].ClassName);
-        }
-    }
-	class'BC_WeaponInfoCache'.static.EndSession();
-	SaveConfig();
-	lb_NewWeapons.CheckList.OnClick = InternalOnClick;
-
-    PresetNames = GetPerObjectNames("BallisticProV55", "BallisticSwapPreset");
-    for (i = 0; i < PresetNames.Length; i++)
-        cb_Presets.AddItem(PresetNames[i], new(None, PresetNames[i]) class'BallisticSwapPreset',);
-    cb_Presets.SetIndex(0);
-    cb_Presets.SetText("");
-
-    ch_Independent.MyCheckBox.OnClick = InternalOnClick;
-}
-*/
 function InternalOnChange(GUIComponent Sender)
 {
 	if (Sender == cb_Presets && cb_Presets.GetObject() != None)

--- a/BallisticProV55/Classes/ConfigTab_WeaponRules.uc
+++ b/BallisticProV55/Classes/ConfigTab_WeaponRules.uc
@@ -125,7 +125,7 @@ defaultproperties
      sl_Recoil=moSlider'sl_RecoilSlider'
 
      Begin Object Class=moSlider Name=sl_ReloadSlider
-         MaxValue=2.000000
+         MaxValue=3.000000
          MinValue=0.500000
          Caption="Reload Scale"
          OnCreateComponent=sl_RecoilSlider.InternalOnCreateComponent

--- a/BallisticProV55/Classes/Fifty9MachinePistol.uc
+++ b/BallisticProV55/Classes/Fifty9MachinePistol.uc
@@ -303,15 +303,6 @@ simulated function PlayIdle()
 		super.PlayIdle();
 }
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2)
-		PlayAnim('ReloadEndCock', CockAnimRate, 0.2);
-	else
-		PlayAnim(CockAnim, CockAnimRate, 0.2);
-}
-
-
 simulated function Notify_Fifty9Melee()
 {
 	if (Role == ROLE_Authority)

--- a/BallisticProV55/Classes/G5Mortar.uc
+++ b/BallisticProV55/Classes/G5Mortar.uc
@@ -153,8 +153,8 @@ simulated function Tick(float DT)
 		else			// Head for the target
 		{
 			V = LastLoc - Location;
-			MaxSpeed = default.MaxSpeed * 3.0;
-			AccelSpeed = default.AccelSpeed * 3.0;
+			MaxSpeed = default.MaxSpeed * 2.0;
+			AccelSpeed = default.AccelSpeed * 2.0;
 		}
 
 		// Align velocity towards target, but limit how fast rocket can turn. Use a tricky units per second rate limit.

--- a/BallisticProV55/Classes/G5Mortar.uc
+++ b/BallisticProV55/Classes/G5Mortar.uc
@@ -151,7 +151,11 @@ simulated function Tick(float DT)
 		if (bPeaking)	// Head for the peak
 			V = Peak - Location;
 		else			// Head for the target
+		{
 			V = LastLoc - Location;
+			MaxSpeed = default.MaxSpeed * 3.0;
+			AccelSpeed = default.AccelSpeed * 3.0;
+		}
 
 		// Align velocity towards target, but limit how fast rocket can turn. Use a tricky units per second rate limit.
 		X = Normal(Velocity);
@@ -250,10 +254,10 @@ simulated singular function HitWall(vector HitNormal, actor Wall)
 defaultproperties
 {
      TurnRate=49152.000000
-     AccelSpeed=750.000000
+     AccelSpeed=850.000000
      MyRadiusDamageType=Class'BallisticProV55.DTG5MortarRadius'
-     Speed=3500.000000
-     MaxSpeed=5000.000000
+     Speed=4000.000000
+     MaxSpeed=6000.000000
      DamageRadius=378.000000
      MyDamageType=Class'BallisticProV55.DTG5Mortar'
      LifeSpan=0.000000

--- a/BallisticProV55/Classes/GRS9Pistol.uc
+++ b/BallisticProV55/Classes/GRS9Pistol.uc
@@ -368,14 +368,6 @@ simulated function OnScopeViewChanged()
 		SightOffset.Y = default.SightOffset.Y * -1;
 }
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2)
-		PlayAnim('ReloadEndCock', CockAnimRate, 0.2);
-	else
-		PlayAnim(CockAnim, CockAnimRate, 0.2);
-}
-
 simulated function BringUp(optional Weapon PrevWeapon)
 {
 	Super.BringUp(PrevWeapon);

--- a/BallisticProV55/Classes/M353Machinegun.uc
+++ b/BallisticProV55/Classes/M353Machinegun.uc
@@ -123,14 +123,6 @@ simulated function Notify_CockAfterReload()
 		PlayAnim('ReloadFinishHold', ReloadAnimRate, 0.2);
 }
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2 && HasAnim('ReloadEndCock'))
-		PlayAnim('ReloadEndCock', CockAnimRate, 0.2);
-	else
-		PlayAnim(CockAnim, CockAnimRate, 0.2);
-}
-
 simulated function PositionSights ()
 {
 	super.PositionSights();

--- a/BallisticProV55/Classes/M353Machinegun_TW.uc
+++ b/BallisticProV55/Classes/M353Machinegun_TW.uc
@@ -210,14 +210,6 @@ simulated function Notify_CockAfterReload()
 		PlayAnim('ReloadFinishHandle', ReloadAnimRate, 0.2);
 }
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2 && HasAnim('ReloadEndCock'))
-		PlayAnim('ReloadEndCock', CockAnimRate, 0.2);
-	else
-		PlayAnim(CockAnim, CockAnimRate, 0.2);
-}
-
 simulated function PositionSights ()
 {
 	super.PositionSights();

--- a/BallisticProV55/Classes/M46AssaultRifle.uc
+++ b/BallisticProV55/Classes/M46AssaultRifle.uc
@@ -122,7 +122,7 @@ simulated function LoadGrenade()
 	if (ReloadState == RS_None)
 	{
 		ReloadState=RS_Cocking;
-		PlayAnim(GrenadeLoadAnim, 1.1, , 0);
+		PlayAnim(GrenadeLoadAnim, ReloadAnimRate+0.1, , 0);
 	}
 }
 
@@ -376,7 +376,7 @@ defaultproperties
 	SpecialInfo(0)=(Info="240.0;25.0;0.9;70.0;0.9;0.2;0.7")
     BringUpSound=(Sound=Sound'BW_Core_WeaponSound.M50.M50Pullout',Volume=0.225000)
     PutDownSound=(Sound=Sound'BW_Core_WeaponSound.M50.M50Putaway',Volume=0.225000)
-	CockAnimPostReload="ReloadEndCock"
+	//CockAnimPostReload="ReloadEndCock"
 	CockSound=(Sound=Sound'BW_Core_WeaponSound.OA-AR.OA-AR_Cock',Volume=1.100000)
 	ClipHitSound=(Sound=Sound'BW_Core_WeaponSound.OA-AR.OA-AR_ClipHit',Volume=1.000000)
 	ClipOutSound=(Sound=Sound'BW_Core_WeaponSound.OA-AR.OA-AR_ClipOut',Volume=1.000000)

--- a/BallisticProV55/Classes/M50AssaultRifle.uc
+++ b/BallisticProV55/Classes/M50AssaultRifle.uc
@@ -219,7 +219,7 @@ simulated function LoadGrenade()
 	if (ReloadState == RS_None)
 	{
 		ReloadState = RS_Cocking;
-		PlayAnim(GrenadeLoadAnim, 1.1, , 0);
+		PlayAnim(GrenadeLoadAnim, ReloadAnimRate+0.1, , 0);
 	}		
 }
 
@@ -991,7 +991,7 @@ defaultproperties
 	SpecialInfo(0)=(Info="240.0;25.0;0.9;80.0;0.7;0.7;0.4")
     BringUpSound=(Sound=Sound'BW_Core_WeaponSound.M50.M50Pullout',Volume=0.225000)
     PutDownSound=(Sound=Sound'BW_Core_WeaponSound.M50.M50Putaway',Volume=0.225000)
-	CockAnimPostReload="ReloadEndCock"
+	//CockAnimPostReload="ReloadEndCock"
 	CockSound=(Sound=Sound'BW_Core_WeaponSound.M50.M50Cock')
 	ClipHitSound=(Sound=Sound'BW_Core_WeaponSound.M50.M50ClipHit')
 	ClipOutSound=(Sound=Sound'BW_Core_WeaponSound.M50.M50ClipOut')

--- a/BallisticProV55/Classes/M763Shotgun.uc
+++ b/BallisticProV55/Classes/M763Shotgun.uc
@@ -331,9 +331,16 @@ function float SuggestDefenseStyle()
 simulated function PlayCocking(optional byte Type)
 {
 	local float Rand;
+	local float AdjustedCockAnimRate;
+
+    // Adjust cock animation rate only during reloading
+    if (ReloadState != RS_None && ReloadState != RS_Cocking)
+        AdjustedCockAnimRate = CockAnimRate * class'BallisticReplicationInfo'.default.ReloadScale;
+    else
+        AdjustedCockAnimRate = CockAnimRate; // Use default rate for firing
 	
 	if (Type == 2 && HasAnim(CockAnimPostReload))
-		SafePlayAnim(CockAnimPostReload, CockAnimRate, 0.2, , "RELOAD");
+		SafePlayAnim(CockAnimPostReload, AdjustedCockAnimRate, 0.2, , "RELOAD");
 	else
 	{	
 		Rand = FRand();
@@ -347,7 +354,7 @@ simulated function PlayCocking(optional byte Type)
 			CockAnim = 'Cock4';
 		else
 			CockAnim = 'Cock5';
-		SafePlayAnim(CockAnim, CockAnimRate, 0.2, , "RELOAD");
+		SafePlayAnim(CockAnim, AdjustedCockAnimRate, 0.2, , "RELOAD");
 	}
 }
 

--- a/BallisticProV55/Classes/M925Machinegun_TW.uc
+++ b/BallisticProV55/Classes/M925Machinegun_TW.uc
@@ -209,14 +209,6 @@ simulated function Notify_CockAfterReload()
 		PlayAnim('ReloadFinishHandle', ReloadAnimRate, 0.2);
 }
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2 && HasAnim('ReloadEndCock'))
-		PlayAnim('ReloadEndCock', CockAnimRate, 0.2);
-	else
-		PlayAnim(CockAnim, CockAnimRate, 0.2);
-}
-
 simulated function bool HasAmmo()
 {
 	//First Check the magazine

--- a/BallisticProV55/Classes/MarlinRifle.uc
+++ b/BallisticProV55/Classes/MarlinRifle.uc
@@ -419,17 +419,6 @@ simulated function WeaponTick (float DT)
 	super.WeaponTick(DT);
 }
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2 && HasAnim(CockAnimPostReload))
-		SafePlayAnim(CockAnimPostReload, CockAnimRate, 0.2, , "RELOAD");
-	else
-		SafePlayAnim(CockAnim, CockAnimRate, 0.2, , "RELOAD");
-
-	//if (SightingState != SS_None)
-	//	TemporaryScopeDown(Default.SightingTime*Default.SightingTimeScale);
-}
-
 // Animation notify for when cocking action starts. Used to time sounds
 simulated function Notify_CockAimed()
 {

--- a/BallisticProV55/Classes/Mut_BallisticSwap.uc
+++ b/BallisticProV55/Classes/Mut_BallisticSwap.uc
@@ -101,9 +101,16 @@ simulated function PreBeginPlay()
 	for(i=0;i<NumWeapons;i++)
 	{
 		Swaps[i].CurrentIndex = Rand(Swaps[i].NewClassNames.length);
+		Swaps[i].NewClasses.Length = Swaps[i].NewClassNames.Length;
 		for (j=0;j<Swaps[i].NewClassNames.length;j++)
+		{
 			if (Swaps[i].NewClassNames[j] != "")
+			{
 				Swaps[i].NewClasses[j] = class<Weapon>(DynamicLoadObject( Swaps[i].NewClassNames[j], class'class' ));
+				if (Swaps[i].NewClasses[j] == None)
+                    log("Error: Failed to load weapon class for " $ Swaps[i].NewClassNames[j]);
+			}
+		}
 	}
 	// Generate ammo swap lists.
 	// If weapon fire mode class matches ammo, pass over some data.
@@ -113,6 +120,7 @@ simulated function PreBeginPlay()
 			{
 				AmmoSwaps[i].CurrentIndex = Swaps[j].CurrentIndex;
 				AmmoSwaps[i].bIndependant = Swaps[j].bRandom;
+				AmmoSwaps[i].NewClasses.Length = Swaps[j].NewClasses.Length;
 				for (k=0;k<Swaps[j].NewClasses.length;k++)
 				{
 					if (class<BallisticWeapon>(Swaps[j].NewClasses[k]) != None && class<BallisticWeapon>(Swaps[j].NewClasses[k]).static.RecommendAmmoPickup(-1) != None)

--- a/BallisticProV55/Classes/Mut_BallisticSwap.uc
+++ b/BallisticProV55/Classes/Mut_BallisticSwap.uc
@@ -525,10 +525,13 @@ function SwapLockers()
 					for (i=0; i < NumWeapons; i++)
 					{
 						//initial case, replacing default weapons
-						if(L.Weapons[j].WeaponClass == GetInventoryFor(Swaps[i].Old))
+						if(L.Weapons[j].WeaponClass != None && L.Weapons[j].WeaponClass == GetInventoryFor(Swaps[i].Old))
 						{
 							L.Weapons[j].WeaponClass = Swaps[i].NewClasses[Rand(Swaps[i].NewClasses.length)];
-							L.Weapons[j].ExtraAmmo = L.Weapons[j].WeaponClass.default.FireModeClass[0].default.AmmoClass.default.InitialAmount;
+							if (L.Weapons[j].WeaponClass != None) // Ensure WeaponClass is valid before accessing its properties
+                        	{
+								L.Weapons[j].ExtraAmmo = L.Weapons[j].WeaponClass.default.FireModeClass[0].default.AmmoClass.default.InitialAmount;
+							}
 							break;
 						}
 					}
@@ -538,9 +541,15 @@ function SwapLockers()
 				//thus, will ignore avril, grenade, mines and anything else which shares a slot, using the rocket, flak and bio instead
 				else
 				{
-					k = Max(0, L.Weapons[j].WeaponClass.default.InventoryGroup - 1);
-					L.Weapons[j].WeaponClass = Swaps[k].NewClasses[Rand(Swaps[k].NewClasses.length)];
-					L.Weapons[j].ExtraAmmo = L.Weapons[j].WeaponClass.default.FireModeClass[0].default.AmmoClass.default.InitialAmount;
+					if (L.Weapons[j].WeaponClass != None)
+					{
+						k = Max(0, L.Weapons[j].WeaponClass.default.InventoryGroup - 1);
+						L.Weapons[j].WeaponClass = Swaps[k].NewClasses[Rand(Swaps[k].NewClasses.length)];
+						if (L.Weapons[j].WeaponClass != None) // Ensure WeaponClass is valid before accessing its properties
+						{
+							L.Weapons[j].ExtraAmmo = L.Weapons[j].WeaponClass.default.FireModeClass[0].default.AmmoClass.default.InitialAmount;
+						}
+					}
 				}
 		}
 		Lockers[Lockers.length] = L;

--- a/BallisticProV55/Classes/Mut_TeamOutfitting.uc
+++ b/BallisticProV55/Classes/Mut_TeamOutfitting.uc
@@ -503,7 +503,8 @@ function bool CheckReplacement(Actor Other, out byte bSuperRelevant)
 	// No ammo pickups
 	else if (Ammo(Other) != None && IP_AmmoPack(Other) == None)
 	{
-		Pickup(Other).myMarker.bBlocked = True;
+		if(Pickup(Other).myMarker != None)
+			Pickup(Other).myMarker.bBlocked = True;
 		return false;
 	}
 	// Lockers replaced with ammo packs
@@ -511,7 +512,8 @@ function bool CheckReplacement(Actor Other, out byte bSuperRelevant)
 	{
 		if (!SpawnNewItem(-1, Other, class'IP_AmmoPack'))
 		{
-			WeaponLocker(Other).myMarker.bBlocked = True;
+			if(WeaponLocker(Other).myMarker != None)
+				WeaponLocker(Other).myMarker.bBlocked = True;
 			Other.GotoState('Disabled');
 			return false;
 		}

--- a/BallisticProV55/Classes/R78Rifle.uc
+++ b/BallisticProV55/Classes/R78Rifle.uc
@@ -126,17 +126,6 @@ simulated function BringUp(optional Weapon PrevWeapon)
 		SetBoneScale (0, 0.0, SilencerBone);
 }
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2 && HasAnim(CockAnimPostReload))
-		SafePlayAnim(CockAnimPostReload, CockAnimRate, 0.2, , "RELOAD");
-	else
-		SafePlayAnim(CockAnim, CockAnimRate, 0.2, , "RELOAD");
-
-	if (SightingState != SS_None && Type != 1)
-		TemporaryScopeDown(0.5);
-}
-
 // Animation notify for when cocking action starts. Used to time sounds
 simulated function Notify_CockAimed()
 {

--- a/BallisticProV55/Classes/RS8Pistol.uc
+++ b/BallisticProV55/Classes/RS8Pistol.uc
@@ -278,14 +278,6 @@ simulated function OnScopeViewChanged()
 		SightOffset.Y = default.SightOffset.Y * -1;
 }
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2)
-		PlayAnim('ReloadEndCock', CockAnimRate, 0.2);
-	else
-		PlayAnim(CockAnim, CockAnimRate, 0.2);
-}
-
 function ServerSwitchSilencer(bool bNewValue)
 {
 	bSilenced = bNewValue;

--- a/BallisticProV55/Classes/RX22AFlamer.uc
+++ b/BallisticProV55/Classes/RX22AFlamer.uc
@@ -104,12 +104,45 @@ simulated event RenderOverlays(Canvas C)
 		C.DrawActor(GasSpray, false, false, Instigator.Controller.FovAngle);
 	}
 }
-
-simulated event Tick (float DT)
+/* 
+// Will work on this a bit later
+simulated function PhysicsVolumeChange(PhysicsVolume NewVolume)
 {
-	super.Tick(DT);
-	if (HeatLevel > 0 && LastFireTime < level.TimeSeconds - 4)
-		HeatLevel = FMax(0, HeatLevel - DT/10);
+	local RX22AWaterSplash Splash;
+	super.PhysicsVolumeChange(NewVolume);
+	if (HeatLevel > 0)
+	{
+		if(NewVolume.bWaterVolume)
+		{
+			Splash = Spawn(class'RX22AWaterSplash',,, GetBoneCoords('tip').Origin);
+			AttachToBone(Splash, 'tip');
+		}
+		else 
+		{
+			if(Splash != None)
+			{
+				Splash.Kill();
+				DetachFromBone(Splash);
+			}
+		}
+	}
+}
+*/
+simulated event Tick(float DT)
+{
+    super.Tick(DT);
+
+	if(HeatLevel > 0)
+	{
+		if (PhysicsVolume.bWaterVolume)
+		{
+			HeatLevel = FMax(0, HeatLevel - DT * 5);
+		}
+		else if (LastFireTime < Level.TimeSeconds - 4)
+		{
+			HeatLevel = FMax(0, HeatLevel - DT / 10);
+		}
+	}
 }
 
 simulated function WeaponTick (float DT)

--- a/BallisticProV55/Classes/Rules_KillRewards.uc
+++ b/BallisticProV55/Classes/Rules_KillRewards.uc
@@ -13,7 +13,7 @@ function ScoreKill(Controller Killer, Controller Killed)
 
     super.ScoreKill(Killer, Killed);
 
-    if (Killed == None || Killer == None)
+    if (Killed == None || Killer == None || Killer.Pawn == None)
 		return;
 
 	if (Vehicle(Killer.Pawn) != None)

--- a/BallisticProV55/Classes/SARAssaultRifle.uc
+++ b/BallisticProV55/Classes/SARAssaultRifle.uc
@@ -651,7 +651,7 @@ defaultproperties
 	BringUpSound=(Sound=Sound'BW_Core_WeaponSound.XK2.XK2-Pullout',Volume=0.210000) 
 	PutDownSound=(Sound=Sound'BW_Core_WeaponSound.XK2.XK2-Putaway',Volume=0.208000)
 	MeleeFireClass=Class'BallisticProV55.SARMeleeFire'
-	CockAnimPostReload="ReloadEndCock"
+	//CockAnimPostReload="ReloadEndCock"
 	CockSound=(Sound=Sound'BW_Core_WeaponSound.SAR.SAR-Cock')
 	ClipOutSound=(Sound=Sound'BW_Core_WeaponSound.SAR.SAR-ClipOut')
 	ClipInSound=(Sound=Sound'BW_Core_WeaponSound.SAR.SAR-ClipIn')

--- a/BallisticProV55/Classes/SRS900Rifle.uc
+++ b/BallisticProV55/Classes/SRS900Rifle.uc
@@ -168,15 +168,6 @@ simulated event WeaponTick(float DT)
 	}
 }
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2)
-		PlayAnim('ReloadEndCock', CockAnimRate, 0.2);
-	else
-		PlayAnim(CockAnim, CockAnimRate, 0.2);
-	StealthImpulse(0.1);
-}
-
 function ServerSwitchSilencer(bool bDetachSuppressor)
 {
 	SwitchSilencer(bSilenced);

--- a/BallisticProV55/Classes/XK2SubMachinegun.uc
+++ b/BallisticProV55/Classes/XK2SubMachinegun.uc
@@ -90,14 +90,6 @@ simulated function float ChargeBar()
 		return AmpCharge / 10;
 }
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2)
-		PlayAnim('ReloadEndCock', CockAnimRate, 0.2);
-	else
-		PlayAnim(CockAnim, CockAnimRate, 0.2);
-}
-
 //==============================================
 // Suppressor Code
 //==============================================

--- a/BallisticProV55/Classes/XMK5SubMachinegun.uc
+++ b/BallisticProV55/Classes/XMK5SubMachinegun.uc
@@ -287,7 +287,7 @@ defaultproperties
 	PutDownSound=(Sound=Sound'BW_Core_WeaponSound.M50.M50Putaway',Volume=0.220000)
 	AIRating=0.8
 	CurrentRating=0.8
-	CockAnimPostReload="ReloadEndCock"
+	//CockAnimPostReload="ReloadEndCock"
 	CockSound=(Sound=Sound'BW_Core_WeaponSound.OA-SMG.OA-SMG_Cock',Volume=1.350000)
 	ClipOutSound=(Sound=Sound'BW_Core_WeaponSound.OA-SMG.OA-SMG_ClipOut',Volume=1.150000)
 	ClipInSound=(Sound=Sound'BW_Core_WeaponSound.OA-SMG.OA-SMG_ClipIn',Volume=1.150000)

--- a/BallisticProV55/Classes/XRS10SubMachinegun.uc
+++ b/BallisticProV55/Classes/XRS10SubMachinegun.uc
@@ -226,14 +226,6 @@ simulated event RenderOverlays( Canvas Canvas )
 		DrawLaserSight(Canvas);
 }
 
-simulated function PlayCocking(optional byte Type)
-{
-	if (Type == 2)
-		PlayAnim('ReloadEndCock', CockAnimRate, 0.2);
-	else
-		PlayAnim(CockAnim, CockAnimRate, 0.2);
-}
-
 function ServerSwitchSilencer(bool bNewValue)
 {
 	bSilenced = bNewValue;


### PR DESCRIPTION
**Changes:**

* Added crouch sliding.
* Added crouch jumping.
* Stamina recharge delay is now customizable from the menu.
* Menu preferences now allow higher max values for movement and weapon settings.
* Renamed *Jump Drain Factor* to *Jump Drain*, with increased max values.
* The *Pickups* tab is now sorted by weapon type—like the *Loadout* tab—and then alphabetically.
* God mode users no longer experience motion blur or screen flashes (for testing/admin purposes).
* Fixed several typos.
* *Reloading Factor* now affects both the weapon cocking animation after reload and the reload speed of grenades/secondary attachments.
* *Zoom Time Mod* now affects the zoom-in animation speed, not just FOV transition speed.
* Sprinting now correctly displays the stamina bar. (Previously, players had to switch weapons after spawning for it to appear.)
* Fast weapon switching now works with all weapons.
* Target Designator can now zoom in significantly further.
* Ballistic Weapons splash screen fade-out time reduced (1.5s vs. 3s).
* G5 Mortar projectile speed increased, and it now doubles in speed during descent (yes, a bit of power creep).
* RX22A Flamer cools off much faster when submerged in water.
* Melee weapons now trace an area of X=15, Y=15 around swipe points, making melee combat more forgiving.
* Fixed a bug where switching weapons while sprinting could leave the weapon stuck in sprint offset mode, even if disabled in menu preferences.
* Fixed a bug where spamming zoom and weapon switching could cause the FOV to remain zoomed in, even when not actually zoomed.

**Feedback is always appreciated!**
Let me know if any of the weapon changes need to be reverted for balance reasons.
